### PR TITLE
rework the build init scripting

### DIFF
--- a/ni-oe-init-build-env
+++ b/ni-oe-init-build-env
@@ -1,8 +1,0 @@
-TEMPLATECONF=${TEMPLATECONF:-$PWD/sources/meta-nilrt/conf}
-BITBAKEDIR=${BITBAKEDIR:-$PWD/sources/bitbake}
-BUILDDIR=${BUILDDIR:-$PWD/build}
-BB_ENV_EXTRAWHITE=${BB_ENV_EXTRAWHITE:-ENABLE_BUILD_TAG_PUSH}
-
-export PS1="(bb) $PS1"
-export TEMPLATECONF
-source $PWD/sources/openembedded-core/oe-init-build-env

--- a/nilrt-build-init.env
+++ b/nilrt-build-init.env
@@ -1,0 +1,29 @@
+#!/usr/bin/env
+
+SCRIPT_ROOT=$(realpath $(dirname ${BASH_SOURCE:-${0}}))
+
+BITBAKEDIR=${BITBAKEDIR:-${SCRIPT_ROOT}/sources/bitbake}
+NILRT_ROOT="${NILRT_ROOT:-${SCRIPT_ROOT}}"
+
+BB_ENV_EXTRAWHITE="${BB_ENV_EXTRAWHITE} ENABLE_BUILD_TAG_PUSH NILRT_ROOT"
+
+# define the location of bitbake configuration files, which will be copied
+# into the build workspace, if one needs to be created.
+TEMPLATECONF=${TEMPLATECONF:-${SCRIPT_ROOT}/sources/meta-nilrt/conf}
+
+export TEMPLATECONF
+export NILRT_ROOT
+
+# Call OE-upstream's build env initialization script, which will create a build
+# workspace called either "${1:-build}/" and `cd` into it.
+. $PWD/sources/openembedded-core/oe-init-build-env
+
+# Add a marker to the prompt based on whether or not bitbake is in the
+# environment.
+if which bitbake >/dev/null; then
+	if [[ ! "${PS1}" =~ ^\(bb\).* ]]; then
+		export PS1="(bb) $PS1"
+	fi
+else
+	echo "ERROR: 'bitbake' command is not available in the environment."
+fi

--- a/scripts/azdo/pipeline.yml
+++ b/scripts/azdo/pipeline.yml
@@ -20,5 +20,5 @@ jobs:
   - checkout: self
     submodules: true
   - script: |
-      source ni-oe-init-build-env
+      source nilrt-build-init.env
       ../scripts/buildall.sh


### PR DESCRIPTION
The `ni-oe-init-build-env` sourcefile was useful to initialize the build
workspace for the nilrt-nxg build pipeline.

Make the script useful in the new build workflow, by:
* defining new build context variables (NILRT_ROOT), for use in the new
  local.conf file.
* letting the user sanely re-source the script from an
  already-initialized shell.
* giving it a more descriptive name: nilrt-build-init.env

Signed-off-by: Alex Stewart <alex.stewart@ni.com>