### PR TITLE
buildVM: enable bridged networking in QEMU VMs

### DIFF
--- a/scripts/buildVM-files/runQemuVM.sh
+++ b/scripts/buildVM-files/runQemuVM.sh
@@ -1,23 +1,45 @@
 #!/bin/bash
 set -e
 
-function usage() {
+# Populate the $macaddr variable with a randomly generated MAC address in the
+# 52:54:::: range.
+generate_random_mac() {
+	printf -v macaddr "52:54:%02x:%02x:%02x:%02x" \
+		$(( $RANDOM & 0xff )) $(( $RANDOM & 0xff )) \
+		$(( $RANDOM & 0xff )) $(( $RANDOM & 0xff ))
+}
+
+# Print usage information to stdout.
+# STDOUT: help text
+usage() {
 	cat <<EOF
-$(basename "$0") [-hs] [-c cpu_count] [-m memory] [-- qemu_args [qemu_args]]
+$(basename "$0") [-h] \\
+    [-a mac_address] [-b bridge] [-c cpu_count] [-m memory] [-s] \\
+    [-- qemu_args [qemu_args]]
 
 Opts:
-	-h    : Display this help and exit.
-	-s    : Start VM in snapshot mode (changes not saved to disk)
+    -h    : Display this help and exit.
+    -s    : Start VM in snapshot mode (changes not saved to disk)
 
 Args:
-	cpu_count : the number of CPUs which will be available to the VM
-	memory    : the amount (in MB) of memory for the VM
-	qemu_args : optional arguments to append to the qemu-system-x86_64 call
+    -a mac_address : Use this static MAC address for the primary NIC, instead of
+                     one which is randomly generated.
+    -b bridge      : Add the VM as a member to this network bridge device.
+    -c cpu_count   : the number of CPUs which will be available to the VM
+    -m memory      : the amount (in MB) of memory for the VM
+    -- qemu_args   : optional arguments to append to the qemu-system-x86_64 call
 EOF
 }
 
-while getopts ":c:hm:s-" opt; do
+
+while getopts ":a:b:c:hm:s-" opt; do
 	case ${opt} in
+		a)
+			macaddr=$OPTARG
+			;;
+		b)
+			if_bridge=$OPTARG
+			;;
 		c)
 			cpu_count=$OPTARG
 			;;
@@ -48,9 +70,19 @@ while getopts ":c:hm:s-" opt; do
 done
 shift $((OPTIND -1))
 
+
 qemu_args=${@:-}
 if [ "$snapshot" = true ] ; then
 	qemu_args="-snapshot ${qemu_args}"
+fi
+
+# determine the VM's primary mac address
+[ -n "${macaddr}" ] || generate_random_mac
+# determine primary NIC configuration
+if [ -n "${if_bridge}" ]; then
+	nilrt_net0_args="tap,ifname=\"$if_bridge\",id=nilrt_net0"
+else
+	nilrt_net0_args="user,id=nilrt_net0"
 fi
 
 SCRIPT_DIR="`dirname "$BASH_SOURCE[0]"`"
@@ -62,4 +94,6 @@ qemu-system-x86_64 \
 	-drive if=pflash,format=raw,readonly,file="$SCRIPT_DIR/OVMF/OVMF_CODE.fd" \
 	-drive if=pflash,format=raw,file="$SCRIPT_DIR/OVMF/OVMF_VARS.fd" \
 	-drive file="$SCRIPT_DIR/${VM_NAME}.qcow2",index=0,media=disk \
+	-device e1000,netdev=nilrt_net0,mac=$macaddr \
+	-netdev ${nilrt_net0_args} \
 	${qemu_args:-}


### PR DESCRIPTION
Add arguments to the QEMU run-VM scripting, which will enable users to
easily add the VM to an existing network bridge on their host machine.

Also, randomly assign the MAC address of the primary adapter to
discourage IP assignment collisions between multiple VMs on the same subnet.

Randomizing the MAC address means that VMs will have inconsistent IPs
between domain restarts. Users who need a consistent IP should assign
a static MAC address using the new `-a` argument.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

Calling the script with no arguments will initialize the primary NIC with user-mode networking and a randomly-assigned MAC address. Using `-b $bridge_name` will create a TAP interface and attach it to the bridge with name `$bridge_name`; the MAC address will be random. Using `-a $mac_address` will assign either the user-mode NIC or the bridge with a static MAC address.