### PR TITLE
fio-test: Update ioengine from libaio to sync

### DIFF
--- a/scripts/tests/fio-test/iops-file-randread.fio
+++ b/scripts/tests/fio-test/iops-file-randread.fio
@@ -2,7 +2,7 @@
 bs=4K
 iodepth=256
 direct=1
-ioengine=libaio
+ioengine=sync
 group_reporting
 time_based
 runtime=500

--- a/scripts/tests/fio-test/iops-file-randrw.fio
+++ b/scripts/tests/fio-test/iops-file-randrw.fio
@@ -2,7 +2,7 @@
 bs=4K
 iodepth=256
 direct=1
-ioengine=libaio
+ioengine=sync
 group_reporting
 time_based
 runtime=500

--- a/scripts/tests/fio-test/iops-file-read.fio
+++ b/scripts/tests/fio-test/iops-file-read.fio
@@ -2,7 +2,7 @@
 bs=4K
 iodepth=256
 direct=1
-ioengine=libaio
+ioengine=sync
 group_reporting
 time_based
 runtime=500

--- a/scripts/tests/fio-test/latency-randread.fio
+++ b/scripts/tests/fio-test/latency-randread.fio
@@ -2,7 +2,7 @@
 bs=4K
 iodepth=1
 direct=1
-ioengine=libaio
+ioengine=sync
 group_reporting
 time_based
 runtime=500

--- a/scripts/tests/fio-test/latency-randrw.fio
+++ b/scripts/tests/fio-test/latency-randrw.fio
@@ -2,7 +2,7 @@
 bs=4K
 iodepth=1
 direct=1
-ioengine=libaio
+ioengine=sync
 group_reporting
 time_based
 runtime=500

--- a/scripts/tests/fio-test/run_tests.py
+++ b/scripts/tests/fio-test/run_tests.py
@@ -1,8 +1,13 @@
 #!/bin/bash
-opkg update
-opkg install fio
+which fio &> /dev/null || (opkg update; opkg install fio; sleep 5;)
+
+hn=`hostname`
+un=`uname -r`
+dt=`date "+%F-%T"`
+fn="$hn"__"$un"__"$dt".output
 
 for i in *.fio; do
-    echo =========$i========= &>> fio.output;
-    fio $i &>> fio.output;
+    echo =========$i========= &>> $fn;
+    fio $i &>> $fn;
+    sleep 5;
 done

--- a/scripts/tests/fio-test/throughput-file-randread.fio
+++ b/scripts/tests/fio-test/throughput-file-randread.fio
@@ -2,7 +2,7 @@
 bs=64K
 iodepth=64
 direct=1
-ioengine=libaio
+ioengine=sync
 group_reporting
 time_based
 runtime=500

--- a/scripts/tests/fio-test/throughput-file-randrw.fio
+++ b/scripts/tests/fio-test/throughput-file-randrw.fio
@@ -2,7 +2,7 @@
 bs=64K
 iodepth=64
 direct=1
-ioengine=libaio
+ioengine=sync
 group_reporting
 time_based
 runtime=500

--- a/scripts/tests/fio-test/throughput-file-read.fio
+++ b/scripts/tests/fio-test/throughput-file-read.fio
@@ -2,7 +2,7 @@
 bs=64K
 iodepth=64
 direct=1
-ioengine=libaio
+ioengine=sync
 group_reporting
 time_based
 runtime=500


### PR DESCRIPTION
Update ioengine to sync and minor improvements to
run_tests.py

@ni/rtos 