### PR TITLE
scripts/azdo: add AZDO component conf files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,13 @@ RT devices - including custom Linux kernels and kernel modules.
     initialization script at the project root.
 
     ```bash
-    . nilrt-build-init.env
+    . nilrt-build-init.env [--org]
     ```
+
+    <font color=lightgreen>[NI]</font> builders who are connected to the NI
+    corporate network should specify `--org` in their init script args, to
+    provoke the script into adding the `ni-org.conf` snippet to your bitbake
+    directory. External builders *should not* use `--org`.
 
     This will setup the needed environment variables and build configuration
     files for building through the OpenEmbedded build system. Note that the

--- a/nilrt-build-init.env
+++ b/nilrt-build-init.env
@@ -2,6 +2,21 @@
 
 SCRIPT_ROOT=$(realpath $(dirname ${BASH_SOURCE:-${0}}))
 
+enable_ni_org_conf=false
+positionals=()
+
+while [ $# -ge 1 ]; do case "$1" in
+	-o|--org)
+		enable_ni_org_conf=true
+		shift
+		;;
+	*)
+		positionals+=($1)
+		shift
+		;;
+esac; done
+
+
 BITBAKEDIR=${BITBAKEDIR:-${SCRIPT_ROOT}/sources/bitbake}
 NILRT_ROOT="${NILRT_ROOT:-${SCRIPT_ROOT}}"
 
@@ -16,7 +31,15 @@ export NILRT_ROOT
 
 # Call OE-upstream's build env initialization script, which will create a build
 # workspace called either "${1:-build}/" and `cd` into it.
-. $PWD/sources/openembedded-core/oe-init-build-env
+cd ${SCRIPT_ROOT}
+. ./sources/openembedded-core/oe-init-build-env ${positionals[@]}
+
+if $enable_ni_org_conf; then
+	if [ ! -e conf/site.conf ]; then
+		echo "Adding NI org.conf as conf/site.conf..."
+		cp ${SCRIPT_ROOT}/scripts/azdo/conf/ni-org.conf ./conf/site.conf
+	fi
+fi
 
 # Add a marker to the prompt based on whether or not bitbake is in the
 # environment.

--- a/scripts/azdo/conf/auto.conf
+++ b/scripts/azdo/conf/auto.conf
@@ -1,0 +1,12 @@
+# Include buildhistory as it is used by toaster as well as generally
+# useful in detecting changes in builds/configurations
+INHERIT += "buildhistory"
+BUILDHISTORY_COMMIT = "1"
+
+# Generates a "cve/cve.log" in every recipe's work dir.
+# https://wiki.yoctoproject.org/wiki/How_do_I#Q:_How_do_I_get_a_list_of_CVEs_patched.3F
+#INHERIT += "cve-check"
+
+# The buildstats class records performance statistics about each task executed
+# during the build (e.g. elapsed time, CPU usage, and I/O usage).
+USER_CLASSES += "buildstats"

--- a/scripts/azdo/conf/auto.conf
+++ b/scripts/azdo/conf/auto.conf
@@ -5,7 +5,7 @@ BUILDHISTORY_COMMIT = "1"
 
 # Generates a "cve/cve.log" in every recipe's work dir.
 # https://wiki.yoctoproject.org/wiki/How_do_I#Q:_How_do_I_get_a_list_of_CVEs_patched.3F
-#INHERIT += "cve-check"
+INHERIT += "cve-check"
 
 # The buildstats class records performance statistics about each task executed
 # during the build (e.g. elapsed time, CPU usage, and I/O usage).

--- a/scripts/azdo/conf/ni-org.conf
+++ b/scripts/azdo/conf/ni-org.conf
@@ -1,0 +1,19 @@
+# This configuration file contains bitbake settings which are only viable when
+# building inside of the NI corporate network. Public builders should not
+# include this file.
+
+#
+# Enable source mirroring via NI's snapshot server.
+#
+INHERIT += "own-mirrors"
+BB_GENERATE_MIRROR_TARBALLS = "1"
+SOURCE_MIRROR_URL ?= "http://git.amer.corp.natinst.com/snapshots"
+
+# The network based PR service host and port Set PRSERV_HOST to 'localhost:0'
+# to automatically start local PRService.
+PRSERV_HOST = "versionator.amer.corp.natinst.com:8585"
+
+#
+# Internal feed configuration.
+#
+NILRT_FEEDS_URI ?= "http://nickdanger.amer.corp.natinst.com/feeds"


### PR DESCRIPTION
Add an auto.conf file, containing bitbake configuration settings which
(a) are common to all NI-internal AZDO bitbake components and (b) have
static values.

Add an ni-org.conf file, containing bitbake configuration settings which
are necessary to produce faster, more-reproducible builds, but which are
insane for an external (non-NI) builder.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

### Testing

* Rebuilt `rtos_oe_feeds` on my dev machine and verified that the variables I moved have their correct values and that all makefile targets complete.

### Associated PRs
* meta-nilrt [PR 125](https://github.com/ni/meta-nilrt/pull/125) for the nilrt.git angle on this change.
* [AZDO](https://dev.azure.com/ni/DevCentral/_git/ni-central/pullrequest/123493)