### PR TITLE
ni-org.conf: enable root login

### DIFF
--- a/scripts/azdo/conf/ni-org.conf
+++ b/scripts/azdo/conf/ni-org.conf
@@ -17,3 +17,8 @@ PRSERV_HOST = "versionator.amer.corp.natinst.com:8585"
 # Internal feed configuration.
 #
 NILRT_FEEDS_URI ?= "http://nickdanger.amer.corp.natinst.com/feeds"
+
+# Temporarily enable root login without a password, for dunfell development.
+# Remove these settings when NI-Auth becomes available to the image build
+# stage.
+EXTRA_IMAGE_FEATURES += "empty-root-password allow-empty-password"


### PR DESCRIPTION
While we are waiting for an internal NI-Auth subfeed for the dunfell
release, enable passwordless root login for NI developers. This commit
should be reverted by release builders.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

@ni/rtos @jeminor 