### PR TITLE
scripts: update Dockerfiles

### DIFF
--- a/scripts/azdo/Makefile
+++ b/scripts/azdo/Makefile
@@ -1,0 +1,21 @@
+
+GIT_SHORTHASH = $(shell git rev-parse --short HEAD)
+
+
+.PHONY: all nilrt-nibuild nilrt-build .FORCE
+
+all : nilrt-nibuild nilrt-build
+
+nilrt-build : .FORCE
+	cd ../docker && docker build \
+		-t nilrt-build:$(GIT_SHORTHASH) \
+		-f Dockerfile \
+		.
+	docker tag nilrt-build:$(GIT_SHORTHASH) nilrt-build:latest
+
+nilrt-nibuild : nilrt-nibuild.Dockerfile nilrt-build .FORCE
+	docker build \
+		-t nilrt-nibuild:$(GIT_SHORTHASH) \
+		-f $< \
+		.
+	docker tag nilrt-nibuild:$(GIT_SHORTHASH) nilrt-nibuild:latest

--- a/scripts/azdo/build-scripts/install-p4-cli.sh
+++ b/scripts/azdo/build-scripts/install-p4-cli.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# This script installs the p4 CLI utility on linux docker images.
+set -xeuo pipefail
+
+p4_release="r19.2"
+p4_cli_uri="https://cdist2.perforce.com/perforce/${p4_release}/bin.linux26x86_64/helix-core-server.tgz"
+p4_sha_uri="https://cdist2.perforce.com/perforce/${p4_release}/bin.linux26x86_64/SHA256SUMS"
+
+tmp_p4=`mktemp -d`
+cd "$tmp_p4"
+wget --no-verbose "${p4_cli_uri}"
+wget --no-verbose "${p4_sha_uri}"
+sha256sum --strict --ignore-missing --check ./SHA256SUMS
+
+tar -xz -f helix-core-server.tgz --to-stdout 'p4' >/usr/bin/p4
+chmod 0755 /usr/bin/p4
+
+rm -rv "$tmp_p4"

--- a/scripts/azdo/nilrt-nibuild.Dockerfile
+++ b/scripts/azdo/nilrt-nibuild.Dockerfile
@@ -1,0 +1,161 @@
+FROM nilrt-build:latest AS nilrt-base
+
+# Install nibuild dependencies
+RUN dpkg --add-architecture i386
+RUN apt-get update && apt-get install --assume-yes \
+	libc6-i686:i386 \
+	libperl5.28:i386 \
+	libstdc++6:i386 \
+""
+RUN apt-get update && apt-get install --assume-yes \
+	build-essential \
+	ccache \
+	chrpath \
+	cvs \
+	desktop-file-utils \
+	diffstat \
+	g++ \
+	gawk \
+	help2man \
+	info \
+	libpulse-dev \
+	pkg-config \
+	subversion \
+	texi2html \
+	texinfo \
+	xmlstarlet \
+""
+
+# Add things the the Python 3.6 compile needs
+RUN apt-get update && apt-get install --assume-yes \
+	liblzma-dev\
+	libncurses5-dev \
+	libsqlite3-dev \
+	libssl-dev \
+""
+
+# All of this is taken from: https://raw.githubusercontent.com/docker-library/python/3dd565218e1007919dec280b5729bd5ddb780345/3.6/stretch/Dockerfile
+# except the src dir has been kept
+# ...and the symlink for python has been kept (not replaced with this one)
+# ...and install pip with python3.6
+
+# extra dependencies (over what buildpack-deps already includes)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		libbluetooth-dev \
+		tk-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
+ENV PYTHON_VERSION 3.6.12
+
+RUN set -ex \
+	\
+	&& wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+	&& wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+	&& gpg --batch --verify python.tar.xz.asc python.tar.xz \
+	&& { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
+	&& rm -rf "$GNUPGHOME" python.tar.xz.asc \
+	&& mkdir -p /usr/src/python \
+	&& tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+	&& rm python.tar.xz \
+	\
+	&& cd /usr/src/python \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--enable-loadable-sqlite-extensions \
+		--enable-optimizations \
+		--enable-option-checking=fatal \
+		--enable-shared \
+		--with-system-expat \
+		--with-system-ffi \
+		--without-ensurepip \
+	&& make -j "$(nproc)" \
+# setting PROFILE_TASK makes "--enable-optimizations" reasonable: https://bugs.python.org/issue36044 / https://github.com/docker-library/python/issues/160#issuecomment-509426916
+		PROFILE_TASK='-m test.regrtest --pgo \
+			test_array \
+			test_base64 \
+			test_binascii \
+			test_binhex \
+			test_binop \
+			test_bytes \
+			test_c_locale_coercion \
+			test_class \
+			test_cmath \
+			test_codecs \
+			test_compile \
+			test_complex \
+			test_csv \
+			test_decimal \
+			test_dict \
+			test_float \
+			test_fstring \
+			test_hashlib \
+			test_io \
+			test_iter \
+			test_json \
+			test_long \
+			test_math \
+			test_memoryview \
+			test_pickle \
+			test_re \
+			test_set \
+			test_slice \
+			test_struct \
+			test_threading \
+			test_time \
+			test_traceback \
+			test_unicode \
+		' \
+	&& make install \
+	\
+	&& find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+			-o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+			-o \( -type f -a -name 'wininst-*.exe' \) \
+		\) -exec rm -rf '{}' + \
+	\
+	&& ldconfig \
+	\
+	&& python3 --version
+
+# make some useful symlinks that are expected to exist
+RUN cd /usr/local/bin \
+	&& ln -s idle3 idle \
+	&& ln -s pydoc3 pydoc \
+	&& ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 20.2.2
+# https://github.com/pypa/get-pip
+ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
+ENV PYTHON_GET_PIP_SHA256 d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
+
+RUN set -ex; \
+	\
+	wget -O get-pip.py "$PYTHON_GET_PIP_URL"; \
+	echo "$PYTHON_GET_PIP_SHA256 *get-pip.py" | sha256sum --check --strict -; \
+	\
+	python3.6 get-pip.py \
+		--disable-pip-version-check \
+		--no-cache-dir \
+		"pip==$PYTHON_PIP_VERSION" \
+	; \
+	pip --version; \
+	\
+	find /usr/local -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' +; \
+	rm -f get-pip.py
+
+
+# Install the perforce cli binary
+COPY build-scripts/install-p4-cli.sh /tmp/install-p4-cli.sh
+RUN  /tmp/install-p4-cli.sh
+

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,14 +1,41 @@
-FROM debian:10
+## LAYER base OS
+FROM debian:10.8 as os-base
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+SHELL ["/bin/bash", "-c"]
 
-RUN sed -i 's/stretch main/stretch main contrib/' /etc/apt/sources.list
-
+# Enable contributor package sources
 ENV DEBIAN_FRONTEND=noninteractive
-
+RUN sed -i 's/stretch main/stretch main contrib/' /etc/apt/sources.list
 RUN apt-get update && apt-get install --assume-yes apt-utils
 
-# Install OE dependencies
+# Install UTF-8 locales
+RUN apt-get update && apt-get install --assume-yes locales
+RUN dpkg-reconfigure -f noninteractive locales
+RUN echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+# Developer tools
+RUN apt-get update && apt-get install --assume-yes \
+	binutils \
+	bvi \
+	bzip2 \
+	coreutils \
+	git \
+	python3 \
+	rsync \
+	strace \
+	sudo \
+	tree \
+	unzip \
+	vim \
+	wget \
+	xz-utils \
+	zip \
+""
+
+# OpenEmbedded/Bitbake dependencies
 RUN apt-get update && apt-get install --assume-yes \
 	bc \
 	build-essential \
@@ -16,6 +43,7 @@ RUN apt-get update && apt-get install --assume-yes \
 	chrpath \
 	cpio \
 	cvs \
+	debianutils \
 	desktop-file-utils \
 	diffstat \
 	gawk \
@@ -32,28 +60,35 @@ RUN apt-get update && apt-get install --assume-yes \
 	libpulse-dev \
 	libsdl1.2-dev \
 	linux-image-amd64 \
-	locales \
 	pigz \
 	pkg-config \
+	pylint3 \
 	python \
 	python-pexpect \
 	python3 \
+	python3-git \
+	python3-jinja2 \
+	python3-pexpect \
+	python3-pip \
 	qemu-kvm \
 	qemu-system-x86 \
 	qemu-utils \
-	rsync \
 	socat \
 	strace \
 	subversion \
-	sudo \
 	texi2html \
 	texinfo \
 	unzip \
 	uuid-runtime \
-	vim \
 	wget \
 	xmlstarlet \
-	zip
+	xterm \
+""
+
+# Testing and Utility dependencies
+RUN apt-get update && apt-get install --assume-yes \
+	expect \
+""
 
 # Install virtualbox from upstream because it's not available in debian 10
 RUN echo 'deb http://download.virtualbox.org/virtualbox/debian buster contrib' > /etc/apt/sources.list.d/virtualbox.list
@@ -62,20 +97,13 @@ RUN apt-key add oracle_vbox_2016.asc
 RUN rm oracle_vbox_2016.asc
 RUN apt-get update && apt-get install --assume-yes virtualbox-6.0
 
-RUN dpkg-reconfigure -f noninteractive locales
-RUN echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen en_US.UTF-8
-RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-
 # Cleanup image of unneeded packages to reduce size
-
 RUN apt-get autoremove --yes && apt-get clean --yes
 RUN rm -rf \
 	/tmp/* \
-	/var/lib/apt/lists/* \
-	/var/tmp/*
-RUN rm -f \
 	/var/cache/apt/*.bin \
 	/var/cache/apt/archives/*.deb \
-	/var/cache/apt/archives/partial/*.deb
-
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+	/var/cache/apt/archives/partial/*.deb \
+	/var/lib/apt/lists/* \
+	/var/tmp/* \
+""


### PR DESCRIPTION
Merge jeminor's Dockerfile, which contains the necessary modifications
to make the build image a viable NIbuild/AZDO container. But break it
into two pieces: under scripts/docker and scripts/azdo, for the generic
and NI-specific components respectively.

The Makefile in :scripts/azdo can be used to create a new nilrt-build
and nilrt-nibuild image. The nilrt-nibuild image should be pushed to the
NI docker registry for use by the build pipeline.


### Testing

* Built the Makefile below and pushed the image to the RnD docker registry.
* Ran [this PR build](https://dev.azure.com/ni/DevCentral/_build/results?buildId=760982&view=results) using the new container image. It seems to work well, but I'm still working on getting the official [merge PR](https://dev.azure.com/ni/DevCentral/_git/ni-central/pullrequest/130046) to work through some nibuild problem (not container-related).

----

@ni/rtos 