### PR TITLE
Many updates to the buildVM script

### DIFF
--- a/scripts/buildVM.sh
+++ b/scripts/buildVM.sh
@@ -29,8 +29,6 @@ Arguments:
   -n name         The name of the final VM archive
   -r recipe_name  The name of the recovery media ISO, within the images_dir
                   Example: \`foo-bar-x64.iso\` has recipe_name: \`foo-bar\`
-  -v              Enable verbose mode. VM serial output will be connected to
-                  stdout.
 EOF
     exit $rc
 }
@@ -43,10 +41,9 @@ initramfsRecipeName=""
 bootDiskSizeMB=""
 memSizeMB=""
 answerFile=""
-verbose_mode=0
 imagesDir=""
 
-while getopts "i:n:r:d:m:a:hv" opt; do
+while getopts "i:n:r:d:m:a:h" opt; do
    case "$opt" in
    a )  answerFile="$OPTARG" ;;
    d )  bootDiskSizeMB="$OPTARG" ;;
@@ -55,17 +52,10 @@ while getopts "i:n:r:d:m:a:hv" opt; do
    m )  memSizeMB="$OPTARG" ;;
    n )  vmName="$OPTARG" ;;
    r )  initramfsRecipeName="$OPTARG" ;;
-   v )  verbose_mode=1 ;;
    \?)  print_usage_and_die ;;
    esac
 done
 shift $(($OPTIND - 1))
-
-if [ "$verbose_mode" -eq 0 ] ; then
-    do_silent() { "$@" &>/dev/null; }
-else
-    do_silent() { "$@"; }
-fi
 
 [ -n "$vmName" ] || error_and_die 'Must specify VM name with -n. Run with -h for help.'
 [ -n "$initramfsRecipeName" ] || error_and_die 'Must specify recipe name with -r. Run with -h for help.'
@@ -111,7 +101,7 @@ enableKVM=$(id | grep -q kvm && echo "-enable-kvm -cpu kvm64" || echo "")
 isoImage="$imagesDir/$initramfsRecipeName-x64.iso"
 [ ! -f $isoImage ] && isoImage="$imagesDir/$initramfsRecipeName-x64.wic"
 
-do_silent qemu-system-x86_64 \
+qemu-system-x86_64 \
     $enableKVM -smp cpus=1 \
     -m "$memSizeMB" \
     -nographic \

--- a/scripts/buildVM.sh
+++ b/scripts/buildVM.sh
@@ -120,7 +120,7 @@ do_silent qemu-system-x86_64 \
     -drive file="$vmDirQemu/$vmName-$MACHINE.qcow2",index=0,media=disk \
     -drive file="$isoImage",index=1,media=cdrom,readonly \
     -drive file="$workingDir/ni_provisioning.answers.iso",index=2,media=cdrom,readonly \
-    </dev/null
+# end qemu-system-x86_64
 
 echo "Built qcow2 disk at $vmDirQemu/$vmName-$MACHINE.qcow2"
 

--- a/scripts/buildVM.sh
+++ b/scripts/buildVM.sh
@@ -34,6 +34,7 @@ EOF
 }
 
 readonly SCRIPT_RESOURCE_DIR="`dirname "$BASH_SOURCE[0]"`/buildVM-files"
+readonly MACHINE=x64
 
 # get args
 vmName=""


### PR DESCRIPTION
While debugging the issues in [meta-nilrt PR 142](https://github.com/ni/meta-nilrt/pull/142), I made several quality of life improvements to the buildVM script.

1. cleaned up the `usage()` function to be more correct and elegant.
2. allowed user-interaction with the provisioning script.
3. make the script verbose, by default.
4. stop forcing the user to set `MACHINE=x64` unnecessarily.
5. improve KVM detection @gratian 
    * I hope the improved detection will fix the [AZDO build failure here](https://dev.azure.com/ni/DevCentral/_build/results?buildId=773463&view=logs&j=44e70749-ceba-5737-fad1-33069546191c&t=a2065b91-4596-5839-9588-2e1a5df2fc02&l=23108).

---

## TESTING
* I've been using this new script for a while.
* I have not tested the new KVM detection on the AZDO build machines yet. I will not accept this PR until that part is validated.

**NOTICE**
This PR includes some breaking API changes for now the `buildVM.sh` script is called (it deprecates the `-v` and `-q` options). The AZDO pipeline will break without concomitant changes to the Makefiles. I won't pull this PR until that AZDO PR is also accepted.

----

@ni/rtos 