### PR TITLE
buildVM: port KVM detection changes to run script

### DIFF
--- a/scripts/buildVM-files/runQemuVM.sh
+++ b/scripts/buildVM-files/runQemuVM.sh
@@ -85,10 +85,18 @@ else
 	nilrt_net0_args="user,id=nilrt_net0"
 fi
 
+# Enable the KVM hypervisor layer, if it seems like it is supported.
+if [ -w /dev/kvm ]; then
+    echo "INFO: /dev/kvm detected as writable. Enabling KVM hypervisor."
+    enableKVM="-enable-kvm"
+else
+    echo "INFO: /dev/kvm is not writable. KVM will not be enabled."
+fi
+
 SCRIPT_DIR="`dirname "$BASH_SOURCE[0]"`"
 set -x
 qemu-system-x86_64 \
-	-enable-kvm -cpu kvm64 -smp cpus=${cpu_count:-1} \
+	${enableKVM:-} -cpu qemu64 -smp cpus=${cpu_count:-1} \
 	-m "${mem_mbs:-${VM_MEM_SIZE_MB}}" \
 	-nographic \
 	-drive if=pflash,format=raw,readonly,file="$SCRIPT_DIR/OVMF/OVMF_CODE.fd" \


### PR DESCRIPTION
Make the same changes as 23de6175bbb881f61693c0373396ff7d0c06e7da, for
the same reasons, in the actual run-* script for the VM. This change
enables the test_provisioning Makefile target to work on hosts without
KVM permissions.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

I'm an idiot and didn't port the KVM detection changes to the actual run- script (which is what is used by the `test_provisioning` AZDO Makefile target).

@ni/rtos @gratian 