### PR TITLE
azdo: Add script to fetch/push sstate-cache

### DIFF
--- a/scripts/azdo/update_sstate_cache.sh
+++ b/scripts/azdo/update_sstate_cache.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+usage() {
+	local exit_code=${1:-2}
+	test $exit_code -eq 0 || exec 1>&2
+
+	cat <<EOF
+
+Syntax:
+$(basename $BASH_SOURCE) push local_sstate_cache_dir argo_sstate_cache_dir
+   Push the local sstate-cache directory contents to the remote argo
+   server directory.
+
+$(basename $BASH_SOURCE) fetch local_sstate_cache_dir argo_sstate_cache_dir
+   Fetch the latest sstate cache from the remote argo cache directory
+   and install to the local sstate-cache directory.
+
+$(basename $BASH_SOURCE) -h
+   Print this help message and exit
+
+Arguments:
+local_sstate_cache_dir      Path to the local sstate cache directory
+argo_sstate_cache_dir       Path to the remote argo sstate cache directory
+
+EOF
+	exit $exit_code
+}
+
+push_cache() {
+	if [ ! -d $local_sstate_cache_dir -o -z "$(ls -A $local_sstate_cache_dir 2>/dev/null)" ]; then
+		echo $local_sstate_cache_dir is missing/empty. Please provide a valid local_sstate_cache_dir name with sstate-cache contents.
+		usage
+	fi
+
+	mkdir -p $argo_sstate_cache_dir
+	pushd $argo_sstate_cache_dir >/dev/null
+
+	# Copy the contents of the cache to a temp .latest directory
+	# before removing the .latest suffix from the name.
+	temp_argo_dir=$(date +"%s").latest
+	mkdir $temp_argo_dir
+	echo Pushing sstate cache to argo at $temp_argo_dir
+	cp -rL $local_sstate_cache_dir/* $temp_argo_dir/
+	mv $temp_argo_dir ${temp_argo_dir%.latest}
+
+	# Cap the number of cache directories on the argo server at
+	# max_dir_count. Delete older cache directories exceeding the
+	# cap.
+	max_dir_count=5  # arbitrarily chosen number
+	current_dir_count=$(find * -maxdepth 0 -type d 2> /dev/null | wc -l)
+	if [ $current_dir_count -gt $max_dir_count ]; then
+		dirs=$(ls -trd * | head -$(($current_dir_count - $max_dir_count)))
+		for dir in ${dirs[@]}; do
+			echo Removing old sstate cache directory $dir
+			rm -rf $dir
+		done
+	fi
+
+	popd >/dev/null
+}
+
+fetch_cache() {
+	if [ ! -d $argo_sstate_cache_dir ]; then
+		echo Cannot find argo sstate cache directory $argo_sstate_cache_dir
+		usage
+	fi
+
+	pushd $argo_sstate_cache_dir >/dev/null
+
+	mkdir -p $local_sstate_cache_dir
+	# Rsync the latest cache directory, excluding any directory
+	# with a .latest suffix from the search.
+	latest_cache_dir=$(ls -t -I *.latest | head -1)
+	echo Copying over the cache contents from $latest_cache_dir. Might take a while...
+	rsync -rltxSWh --info=STATS1 $latest_cache_dir/ $local_sstate_cache_dir/
+
+	popd >/dev/null
+}
+
+validate_args() {
+	if [ -z $local_sstate_cache_dir ]; then
+		echo Missing local_sstate_cache_dir argument.
+		usage
+	fi
+	if [ -z $argo_sstate_cache_dir ]; then
+		echo Missing argo_sstate_cache_dir argument.
+		usage
+	fi
+}
+
+local_sstate_cache_dir=$2
+argo_sstate_cache_dir=$3
+case "$1" in
+	push)
+		validate_args
+		push_cache
+	;;
+	fetch)
+		validate_args
+		fetch_cache
+	;;
+	--help|-h)
+		usage 0
+	;;
+	*)
+		echo Invalid argument
+		usage
+	;;
+esac
+

--- a/scripts/azdo/update_sstate_cache.sh
+++ b/scripts/azdo/update_sstate_cache.sh
@@ -10,7 +10,8 @@ usage() {
 Syntax:
 $(basename $BASH_SOURCE) push local_sstate_cache_dir argo_sstate_cache_dir
    Push the local sstate-cache directory contents to the remote argo
-   server directory.
+   server directory. Note that this script assumes sequential pushes
+   to the cache.
 
 $(basename $BASH_SOURCE) pull local_sstate_cache_dir argo_sstate_cache_dir
    Fetch the latest sstate cache from the remote argo cache directory

--- a/scripts/azdo/update_sstate_cache.sh
+++ b/scripts/azdo/update_sstate_cache.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 usage() {
 	local exit_code=${1:-2}
@@ -11,7 +12,7 @@ $(basename $BASH_SOURCE) push local_sstate_cache_dir argo_sstate_cache_dir
    Push the local sstate-cache directory contents to the remote argo
    server directory.
 
-$(basename $BASH_SOURCE) fetch local_sstate_cache_dir argo_sstate_cache_dir
+$(basename $BASH_SOURCE) pull local_sstate_cache_dir argo_sstate_cache_dir
    Fetch the latest sstate cache from the remote argo cache directory
    and install to the local sstate-cache directory.
 
@@ -27,21 +28,29 @@ EOF
 }
 
 push_cache() {
-	if [ ! -d $local_sstate_cache_dir -o -z "$(ls -A $local_sstate_cache_dir 2>/dev/null)" ]; then
+	if [ ! -d "$local_sstate_cache_dir" -o -z "$(ls -A $local_sstate_cache_dir 2>/dev/null)" ]; then
 		echo $local_sstate_cache_dir is missing/empty. Please provide a valid local_sstate_cache_dir name with sstate-cache contents.
 		usage
 	fi
 
-	mkdir -p $argo_sstate_cache_dir
-	pushd $argo_sstate_cache_dir >/dev/null
+	mkdir -p "$argo_sstate_cache_dir"
+	pushd "$argo_sstate_cache_dir" >/dev/null
 
 	# Copy the contents of the cache to a temp .latest directory
-	# before removing the .latest suffix from the name.
+	# before removing the .latest suffix from the name. Create a
+	# DONOTUSE file in the .latest directory until the mv operation is
+	# complete. The pull operation will not rsync a folder with this
+	# file. Implement this extra precaution because the mv may not be
+	# atomic on the argo share.
+
 	temp_argo_dir=$(date +"%s").latest
+	trap "{ rm -rf $temp_argo_dir; }" EXIT
 	mkdir $temp_argo_dir
+	touch $temp_argo_dir/DONOTUSE
 	echo Pushing sstate cache to argo at $temp_argo_dir
-	cp -rL $local_sstate_cache_dir/* $temp_argo_dir/
+	cp -rL "$local_sstate_cache_dir"/* $temp_argo_dir/
 	mv $temp_argo_dir ${temp_argo_dir%.latest}
+	rm ${temp_argo_dir%.latest}/DONOTUSE
 
 	# Cap the number of cache directories on the argo server at
 	# max_dir_count. Delete older cache directories exceeding the
@@ -49,7 +58,7 @@ push_cache() {
 	max_dir_count=5  # arbitrarily chosen number
 	current_dir_count=$(find * -maxdepth 0 -type d 2> /dev/null | wc -l)
 	if [ $current_dir_count -gt $max_dir_count ]; then
-		dirs=$(ls -trd * | head -$(($current_dir_count - $max_dir_count)))
+		dirs=$(ls -d * | head -$(($current_dir_count - $max_dir_count)))
 		for dir in ${dirs[@]}; do
 			echo Removing old sstate cache directory $dir
 			rm -rf $dir
@@ -59,20 +68,25 @@ push_cache() {
 	popd >/dev/null
 }
 
-fetch_cache() {
-	if [ ! -d $argo_sstate_cache_dir ]; then
+pull_cache() {
+	if [ ! -d "$argo_sstate_cache_dir" ]; then
 		echo Cannot find argo sstate cache directory $argo_sstate_cache_dir
 		usage
 	fi
 
-	pushd $argo_sstate_cache_dir >/dev/null
+	mkdir -p "$local_sstate_cache_dir"
+	pushd "$argo_sstate_cache_dir" >/dev/null
 
-	mkdir -p $local_sstate_cache_dir
 	# Rsync the latest cache directory, excluding any directory
 	# with a .latest suffix from the search.
-	latest_cache_dir=$(ls -t -I *.latest | head -1)
+	latest_cache_dir=$(ls -r -I *.latest | sed -n 1p)
+	# Exclude a directory with the DONOTUSE file.
+	if [ -e $latest_cache_dir/DONOTUSE ]; then
+		latest_cache_dir=$(ls -r -I *.latest | sed -n 2p)
+	fi
+
 	echo Copying over the cache contents from $latest_cache_dir. Might take a while...
-	rsync -rltxSWh --info=STATS1 $latest_cache_dir/ $local_sstate_cache_dir/
+	rsync -rltxSWh --info=STATS1 "$latest_cache_dir"/ "$local_sstate_cache_dir"/
 
 	popd >/dev/null
 }
@@ -95,9 +109,9 @@ case "$1" in
 		validate_args
 		push_cache
 	;;
-	fetch)
+	pull)
 		validate_args
-		fetch_cache
+		pull_cache
 	;;
 	--help|-h)
 		usage 0

--- a/scripts/azdo/update_sstate_cache.sh
+++ b/scripts/azdo/update_sstate_cache.sh
@@ -51,6 +51,7 @@ push_cache() {
 	echo Pushing sstate cache to argo at $temp_argo_dir
 	cp -rL "$local_sstate_cache_dir"/* $temp_argo_dir/
 	mv $temp_argo_dir ${temp_argo_dir%.latest}
+	trap - EXIT
 	rm ${temp_argo_dir%.latest}/DONOTUSE
 
 	# Cap the number of cache directories on the argo server at


### PR DESCRIPTION
This script will be used by the azdo jobs to sync down the sstate
cache from argo at build time, as well as push the local sstate cache
to argo after the build finishes.
The script maintains a maximum of five sstate cache directories on
the remote location and will delete older directories to maintain the
the limit.

PR runs from azdo [here](https://ni.visualstudio.com/DevCentral/_git/ni-central/pullrequest/136867).
Azdo bug reference [here](https://ni.visualstudio.com/DevCentral/_workitems/edit/1299743).

@ni/rtos 