### PR TITLE
expect files: Increase timeout

### DIFF
--- a/scripts/tests/provisioning/migrate_vm_to_safemode.expect
+++ b/scripts/tests/provisioning/migrate_vm_to_safemode.expect
@@ -33,7 +33,7 @@ expect {
 	}
 }
 
-set timeout 90
+set timeout 180
 # configure opkg
 expect {
 	-re "$USER@.*# $" {
@@ -73,6 +73,7 @@ expect {
 	}
 }
 
+set timeout 500
 expect {
 	"$USER@recovery:/#" {}
 	timeout {

--- a/scripts/tests/provisioning/test_migration_to_rauc.expect
+++ b/scripts/tests/provisioning/test_migration_to_rauc.expect
@@ -33,7 +33,7 @@ expect {
 	}
 }
 
-set timeout 90
+set timeout 180
 # configure opkg
 expect {
 	-re "$USER@.*# $" {

--- a/scripts/tests/provisioning/test_migration_to_safemode.expect
+++ b/scripts/tests/provisioning/test_migration_to_safemode.expect
@@ -41,7 +41,7 @@ expect {
 	}
 }
 
-set timeout 90
+set timeout 180
 # configure opkg
 expect {
 	-re "$USER@.*# $" {


### PR DESCRIPTION
@ni/rtos 

NOTE: Testing on azdo still in progress, but it appears that azdo failures were due to timeout values being too low for non-kvm VMs. It is not clear if console closing on reboot is also part of the problem but increasing the timeout without making any other changes fixes the issue when run locally.