### PR TITLE
auto.conf: Remove cve-check

### DIFF
--- a/scripts/azdo/conf/auto.conf
+++ b/scripts/azdo/conf/auto.conf
@@ -3,10 +3,6 @@
 INHERIT += "buildhistory"
 BUILDHISTORY_COMMIT = "1"
 
-# Generates a "cve/cve.log" in every recipe's work dir.
-# https://wiki.yoctoproject.org/wiki/How_do_I#Q:_How_do_I_get_a_list_of_CVEs_patched.3F
-INHERIT += "cve-check"
-
 # The buildstats class records performance statistics about each task executed
 # during the build (e.g. elapsed time, CPU usage, and I/O usage).
 USER_CLASSES += "buildstats"


### PR DESCRIPTION
Running cve checks significantly slows builds. It is unnecessary to
run them in developer and PR builds. Removing the cve-check here,
and it will be added back in azdo during CI builds.

Test builds were run as part of this Azdo [PR](https://ni.visualstudio.com/DevCentral/_git/ni-central/pullrequest/138235). I'll clean that up and post for review once this change is in.

@ni/rtos 