### PR TITLE
Deprecate meta-orgconf in sumo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,10 +38,6 @@
 	path = sources/meta-security
 	url = ../meta-security.git
 	branch = nilrt/master/sumo
-[submodule "sources/meta-orgconf"]
-	path = sources/meta-orgconf
-	url = ../meta-orgconf.git
-	branch = nilrt/master/sumo
 [submodule "sources/meta-sdr"]
 	path = sources/meta-sdr
 	url = ../meta-sdr.git

--- a/ni-oe-init-build-env
+++ b/ni-oe-init-build-env
@@ -1,8 +1,51 @@
-TEMPLATECONF=${TEMPLATECONF:-$PWD/sources/meta-nilrt/conf}
-BITBAKEDIR=${BITBAKEDIR:-$PWD/sources/bitbake}
-BUILDDIR=${BUILDDIR:-$PWD/build}
-BB_ENV_EXTRAWHITE=${BB_ENV_EXTRAWHITE:-ENABLE_BUILD_TAG_PUSH}
+#!/usr/bin/env
 
-export PS1="(bb) $PS1"
+SCRIPT_ROOT=$(realpath $(dirname ${BASH_SOURCE:-${0}}))
+
+enable_ni_org_conf=false
+positionals=()
+
+while [ $# -ge 1 ]; do case "$1" in
+	-o|--org)
+		enable_ni_org_conf=true
+		shift
+		;;
+	*)
+		positionals+=($1)
+		shift
+		;;
+esac; done
+
+
+BITBAKEDIR=${BITBAKEDIR:-${SCRIPT_ROOT}/sources/bitbake}
+BUILDDIR=${BUILDDIR:-${SCRIPT_ROOT}/build}
+
+BB_ENV_EXTRAWHITE="${BB_ENV_EXTRAWHITE} ENABLE_BUILD_TAG_PUSH"
+
+# define the location of bitbake configuration files, which will be copied
+# into the build workspace, if one needs to be created.
+TEMPLATECONF=${TEMPLATECONF:-${SCRIPT_ROOT}/sources/meta-nilrt/conf}
+
 export TEMPLATECONF
-source $PWD/sources/openembedded-core/oe-init-build-env
+
+# Call OE-upstream's build env initialization script, which will create a build
+# workspace called either "${1:-build}/" and `cd` into it.
+cd ${SCRIPT_ROOT}
+. ./sources/openembedded-core/oe-init-build-env ${positionals[@]}
+
+if $enable_ni_org_conf; then
+	if [ ! -e conf/site.conf ]; then
+		echo "Adding NI org.conf as conf/site.conf..."
+		cp ${SCRIPT_ROOT}/scripts/azdo/conf/ni-org.conf ./conf/site.conf
+	fi
+fi
+
+# Add a marker to the prompt based on whether or not bitbake is in the
+# environment.
+if which bitbake >/dev/null; then
+	if [[ ! "${PS1}" =~ ^\(bb\).* ]]; then
+		export PS1="(bb) $PS1"
+	fi
+else
+	echo "ERROR: 'bitbake' command is not available in the environment."
+fi

--- a/scripts/azdo/conf/ni-org.conf
+++ b/scripts/azdo/conf/ni-org.conf
@@ -1,0 +1,19 @@
+# This configuration file contains bitbake settings which are only viable when
+# building inside of the NI corporate network. Public builders should not
+# include this file.
+
+#
+# Enable source mirroring via NI's snapshot server.
+#
+INHERIT += "own-mirrors"
+BB_GENERATE_MIRROR_TARBALLS = "1"
+SOURCE_MIRROR_URL ?= "http://git.amer.corp.natinst.com/snapshots"
+
+# The network based PR service host and port Set PRSERV_HOST to 'localhost:0'
+# to automatically start local PRService.
+PRSERV_HOST = "versionator.amer.corp.natinst.com:8585"
+
+#
+# Internal feed configuration.
+#
+NILRT_FEEDS_URI ?= "http://nickdanger.amer.corp.natinst.com/feeds"


### PR DESCRIPTION
To deprecate meta-orgconf, some of the org-specific variables it defines need to be moved to an optional conf snippet in nilrt.git. This PR essentially merges the changes to the init env file we have already upstreamed to the dunfell mainline, and adds a similar `ni-org.conf` snippet that we have upstreamed to the same.

Builders can use the org snippet using the same `-o/--org` argument to the init script.

## Testing
* Verified that the new init script works, both with and without the `-o` arg.
* Verified that bitbake can parse the configuration files and that the variables look correct.

----
I expect this PR and the associated meta-nilrt PR will necessitate changes to NIOE to get them building, I'll work on those next.

Ref meta-nilrt [PR 159](https://github.com/ni/meta-nilrt/pull/159).

@ni/rtos 