### PR TITLE
scripts/azdo/conf: add auto.conf

### DIFF
--- a/scripts/azdo/conf/auto.conf
+++ b/scripts/azdo/conf/auto.conf
@@ -1,0 +1,8 @@
+# Include buildhistory as it is used by toaster as well as generally
+# useful in detecting changes in builds/configurations
+INHERIT += "buildhistory"
+BUILDHISTORY_COMMIT = "1"
+
+# The buildstats class records performance statistics about each task executed
+# during the build (e.g. elapsed time, CPU usage, and I/O usage).
+USER_CLASSES += "buildstats"


### PR DESCRIPTION
Sumo pipeline build machines require the buildhistory class to generate
their full accompaniment of export artifacts. Backport the auto.conf
from the dev-mainline to add this class and others which are relevant to
auto-build machines.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

This changelist, plus accompanying NIOE/os-common fixups, should modernize and resolve [this build failure](https://heisenberg.amer.corp.natinst.com/view/nilrt-CG/view/21.0/job/NIOpenEmbedded_Export-8.8/18/consoleFull).

## Testing
Checked the bitbake environment on my build machine and verified that the `buildhistory` class is now included.

@ni/rtos 