### PR TITLE
init: define GIT_REPODIR

### DIFF
--- a/ni-oe-init-build-env
+++ b/ni-oe-init-build-env
@@ -20,7 +20,14 @@ esac; done
 BITBAKEDIR=${BITBAKEDIR:-${SCRIPT_ROOT}/sources/bitbake}
 BUILDDIR=${BUILDDIR:-${SCRIPT_ROOT}/build}
 
-BB_ENV_EXTRAWHITE="${BB_ENV_EXTRAWHITE} ENABLE_BUILD_TAG_PUSH"
+BB_ENV_EXTRAWHITE="${BB_ENV_EXTRAWHITE} \
+	ENABLE_BUILD_TAG_PUSH \
+	GIT_REPODIR \
+"
+
+# Define GIT_REPODIR as the directory containing the OE layer submodule repos.
+# This variable is used by the bblayers.conf file.
+export GIT_REPODIR=${SCRIPT_ROOT}/sources
 
 # define the location of bitbake configuration files, which will be copied
 # into the build workspace, if one needs to be created.


### PR DESCRIPTION
The GIT_REPODIR variable is used by newer bblayers.conf files to locate
the OE layer repos. It is normally defined as a part of the NI-internal
sumo build pipeline environment, but is undefined-by-default in external
builders' environments. As a result, bitbake will refuse to comprehend
the bblayers.conf.

Define GIT_REPODIR in the init script and pass its value to bitbake, to
enable external builders.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---


## Testing

Resolves this bitbake error when you try to start the environment.
```
ERROR: Unable to start bitbake server
ERROR: Server log for this session (/mnt/workspace/build/bitbake-cookerdaemon.log):
--- Starting bitbake server pid 49 at 2021-04-16 15:46:28.461043 ---
ERROR: Layer directory '${GIT_REPODIR}/meta-cloud-services' does not exist! Please check BBLAYERS in /mnt/workspace/build/conf/bblayers.conf
```

@ni/rtos 