### PR TITLE
[Patch V2] tests/provisioning: restrict feed access and empower test wrapper scripts

### DIFF
--- a/scripts/tests/provisioning/migrate_vm_to_safemode.expect
+++ b/scripts/tests/provisioning/migrate_vm_to_safemode.expect
@@ -45,7 +45,7 @@ set timeout 180
 # configure opkg
 expect {
 	-re "$USER@.*# $" {
-		send "rm -f /etc/opkg/base-feeds.conf\r"
+		send "rm -f /etc/opkg/base-feeds.conf /etc/opkg/NI-dist.conf\r"
 		send "touch /etc/opkg/testing.conf\r"
 		set feed_index 0
 		foreach feed_uri $ipk_feeds {

--- a/scripts/tests/provisioning/migrate_vm_to_safemode.expect
+++ b/scripts/tests/provisioning/migrate_vm_to_safemode.expect
@@ -45,6 +45,7 @@ set timeout 180
 # configure opkg
 expect {
 	-re "$USER@.*# $" {
+		send "rm -f /etc/opkg/base-feeds.conf\r"
 		send "touch /etc/opkg/testing.conf\r"
 		set feed_index 0
 		foreach feed_uri $ipk_feeds {

--- a/scripts/tests/provisioning/test_grub_gateway_migration.sh
+++ b/scripts/tests/provisioning/test_grub_gateway_migration.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# This script should be run to verify the functionality of the
+# dist-nilrt-grub-gateway IPK.
+# This test:
+#  * boots an already-provisioned NILRT QEMU virtual machine, using the RAUC
+#    (efi-ab) bootflow.
+#  * configures opkg with a locally-hosted ipk feed
+#  * installs and run the dist-nilrt-grub-gateway IPK, to reprovision the VM as
+#    a legacy safemode (grub) image
+#  * reconfigures opkg with the locally-build dist/ feed
+#  * installs and runs the grub-gateway ptest suite
+#
+#  This script returns 0 when the grub-gateway ptest suite passes, or a
+#  positive value otherwise.
+set -euo pipefail
+#set -x
+
+SCRIPT_ROOT=$(dirname "$BASH_SOURCE")
+
+usage () {
+	cat <<EOF
+$(basename $0) nilrt_vm_directory dist_feed_path other_ipk_feeds
+	       [other_ipk_feeds...]
+EOF
+	exit ${1:-2}
+}
+
+if [ $# -lt 3 ]; then
+	echo "ERROR: invalid or missing arguments." >&2
+	usage
+fi
+
+vm_dir=${1}
+dist_feed=${2}
+ipk_feeds=(${@:3})
+log_file=./$(basename ${BASH_SOURCE%.*}).log
+
+(
+	bash "${SCRIPT_ROOT}/start-vm-using-expect.sh" \
+		${ipk_feeds[@]/#/--ipk-feed /} \
+		--ipk-feed "${dist_feed}" \
+		"${vm_dir}" \
+		migrate_vm_to_safemode.expect
+
+	bash "${SCRIPT_ROOT}/start-vm-using-expect.sh" \
+		--ipk-feed "${dist_feed}" \
+		"${vm_dir}" \
+		test_safemode_provision.expect
+) | tee $log_file
+
+# Quickly parse the test session log for pass/fail status
+# GREP will return code...
+#   0, if the ptest PASS line is present
+#   1, if the line is not present (or is FAIL: or SKIP:)
+#   2, if the log file does not exist for whatever reason
+echo "INFO: Parsing the test log..."
+if grep -E '^PASS: ni_provisioning\W' ./${log_file}; then
+	echo "INFO: grub migration test passes."
+	exit 0
+else
+	echo "INFO: grub migration test failed."
+	exit 1
+fi

--- a/scripts/tests/provisioning/test_grub_gateway_migration.sh
+++ b/scripts/tests/provisioning/test_grub_gateway_migration.sh
@@ -14,7 +14,6 @@
 #  This script returns 0 when the grub-gateway ptest suite passes, or a
 #  positive value otherwise.
 set -euo pipefail
-#set -x
 
 SCRIPT_ROOT=$(dirname "$BASH_SOURCE")
 

--- a/scripts/tests/provisioning/test_provisioning.sh
+++ b/scripts/tests/provisioning/test_provisioning.sh
@@ -7,6 +7,7 @@
 #  * configures opkg with a locally-hosted ipk feed.
 #  * installs and runs the provisioning ISO's ptest package.
 #  * evaluates the ptest results.
+set -euo pipefail
 
 script_dir="$(dirname "$0")"
 

--- a/scripts/tests/provisioning/test_provisioning.sh
+++ b/scripts/tests/provisioning/test_provisioning.sh
@@ -9,7 +9,29 @@
 #  * evaluates the ptest results.
 
 script_dir="$(dirname "$0")"
-source "$script_dir/start-vm-using-expect.sh"
+
+usage () {
+	cat <<EOF
+$(basename $0) nilrt_vm_directory ipk_feeds [ipk_feeds...]
+EOF
+	exit ${1:-2}
+}
+
+if [ $# -lt 2 ]; then
+	echo "ERROR: invalid or missing arguments." >&2
+	usage
+fi
+
+vm_dir=${1}
+ipk_feeds=(${@:2})
+log_file=./$(basename ${BASH_SOURCE%.*}).log
+
+(
+	bash "$script_dir/start-vm-using-expect.sh" \
+		${ipk_feeds[@]/#/--ipk-feed /} \
+		"${vm_dir}" \
+		test_rauc_provision.expect
+) | tee $log_file
 
 # Quickly parse the test session log for pass/fail status
 # GREP will return code...

--- a/scripts/tests/provisioning/test_rauc_provision.expect
+++ b/scripts/tests/provisioning/test_rauc_provision.expect
@@ -49,7 +49,7 @@ set timeout 180
 # configure opkg
 expect {
 	-re "$RE_PROMPT" {
-		send "rm -f /etc/opkg/base-feeds.conf\r"
+		send "rm -f /etc/opkg/base-feeds.conf /etc/opkg/NI-dist.conf\r"
 		send "touch /etc/opkg/testing.conf\r"
 		set feed_index 0
 		foreach feed_uri $ipk_feeds {

--- a/scripts/tests/provisioning/test_rauc_provision.expect
+++ b/scripts/tests/provisioning/test_rauc_provision.expect
@@ -49,6 +49,7 @@ set timeout 180
 # configure opkg
 expect {
 	-re "$RE_PROMPT" {
+		send "rm -f /etc/opkg/base-feeds.conf\r"
 		send "touch /etc/opkg/testing.conf\r"
 		set feed_index 0
 		foreach feed_uri $ipk_feeds {


### PR DESCRIPTION
It would seem that Github didn't like my [previous PR](https://github.com/ni/nilrt/pull/60), and for some reason would not accept new commits to the merge branch. This PR is a replacement, which includes the version 2 commits.

---

This patchset does two primary things:

1. It removes the base-feed.conf opkg sources prior to installing the newly build grub-gateway and provisioning test scripts. This keeps the tests fixtures from accidently downloading old (already published) feed content, if the locally-built feeds don't have what is necessary. We would prefer for the test to just fail in that case, rather than falsely passing.
2. It adds a wrapper script for running the migration tests, and empowers it - and the extant test_provisioning.sh script - to pass the lower-leverl tcl-expect script the files they need, and to parse stdout for the test results. The goal here is to (a) allow external builders to easily call these same wrapper scripts and (b) to generally move test logic out of the AZDO component. There will be an associated AZDO PR, which interfaces with the new wrapper scripts.

Testing

Both test_ targets build on my machine.

---

## Version 2
* Also remove the /etc/opkg/NI-dist.conf feed source for the same reason. [commit](https://github.com/ni/nilrt/pull/61/commits/271f22e0e747311deacc1bfb87a5e56f6087af68).

Testing
* Rebuilt test_ targets on my dev machine and confirmed that they still work and look good.

@ni/rtos