### PR TITLE
update_sstate_cache.sh: Skipping push/pull requests

### DIFF
--- a/scripts/azdo/update_sstate_cache.sh
+++ b/scripts/azdo/update_sstate_cache.sh
@@ -106,6 +106,10 @@ validate_args() {
 
 local_sstate_cache_dir=$2
 argo_sstate_cache_dir=$3
+
+echo SKIP: Skipping the push/pull request for the short-term
+exit 0
+
 case "$1" in
 	push)
 		validate_args


### PR DESCRIPTION
Skip push/pull requests from the CI builds until some
corner cases wrt multiple mounts and empty directores can
be addressed.

Signed-off-by: Bill Pittman <bill.pittman@ni.com>