### PR TITLE
README: use correct machine for ARM

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ of NILRT for your hardware.
 
     Run the following command to configure for ARM targets:
 
-        export MACHINE=xilinx-zynqhf
+        export MACHINE=xilinx-zynq
 
     or the following command to configure for x64 targets:
 


### PR DESCRIPTION
We expected that the nilrt distro would be able to pull a clean break
with NXG and allow us the opportunity to switch to a hardfloat ABI.
However, this has long ceased to be the case, and this stale reference
to xilinx-zynqhf in the documentation is not correct for anyone who
wants to build packages on current nilrt. Update it to the right value.

Fixes: c3ffdb9b8f6f ("README: Document building NILRT for both ARM and x64")
Signed-off-by: Brandon Streiff <brandon.streiff@ni.com>