### PR TITLE
Revert "gitmodules: remove meta-measured"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,6 +46,10 @@
 	path = sources/meta-java
 	url = ../meta-java.git
 	branch = nilrt/master/hardknott
+[submodule "sources/meta-measured"]
+	path = sources/meta-measured
+	url = ../meta-measured.git
+	branch = nilrt/master/hardknott
 [submodule "sources/meta-qt5"]
 	path = sources/meta-qt5
 	url = ../meta-qt5.git


### PR DESCRIPTION
This reverts commit 26ace02a6eeb00aaee3670c79e13f6318e89e88b.

Add meta-measured back to the layer stack, and set its upstream head to
`nilrt/master/hardknott`. We cannot efficiently drop meta-measured until
we put more work into meta-nilrt, to drop its dependencies.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>