### PR TITLE
scripts: add pr-server docker container

### DIFF
--- a/scripts/azdo/pr-server/README.md
+++ b/scripts/azdo/pr-server/README.md
@@ -1,0 +1,38 @@
+# NILRT PatchRev Server Container
+
+## Starting the Server
+
+The PR server can be started with sensible defaults through the normal `docker-compose up` workflow.
+
+```bash
+docker-compose -f pr-server.compose.yml up pr-server
+```
+
+This command will start the PR service on network port `0.0.0.0` and port `8585`.
+
+## Configuring the Server
+
+### Build-time arguments
+
+These values are set or passed to the `pr-server.Dockerfile`.
+
+* `PRSERVER_BB_REF` sets the upstream `bitbake` git object reference, which will be the target of the `git clone` operation during container setup. This value is directly passed to the `--branch` argument of `git clone`.
+* `PRSERVER_BB_REMOTE` sets the remote URL of the upstream `bitbake` repo.
+
+### Run-time environment variables
+
+These values are set or passed to the `pr-server.compose.yml`.
+
+* `PRSERVER_HOST` sets the container ipv4 address through which the PR server will be hosted.
+* `PRSERVER_PORT` sets the container ipv4 port through which the PR server will be hosted.
+* `VERBOSE` raises the PR server `loglevel` to `DEBUG`, if set to `"true"`. Otherwise, the loglevel is set to `INFO`.
+
+## Container Architecture
+
+The `pr-server` container is based upon the upstream [python](https://hub.docker.com/_/python) docker container layer. It's mission is to setup and run a single instance of the bitbake PatchRev server.
+
+The container sources its implementation of the bitbake PR server from a shallow-clone of an upstream `bitbake` git repo instance. The bitbake source is checked out to the `WORKDIR` (`/srv/bitbake`), and the server is run using an unprivileged system user account called `bitbake`.
+
+The PR server database `.sqlite3` file and log file are stored in the `/var/pr-server` directory. This directory is volatile with respect to the lifetime of the container overlay. To permanently retain the databse and log file, bind-mount the data directory to a persistent location on the container host machine.
+
+It is a terrible idea to have multiple instances of this container accessing the same underlying database file.

--- a/scripts/azdo/pr-server/init.prserver.sh
+++ b/scripts/azdo/pr-server/init.prserver.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+PRSERVER_DATA=/var/pr-server
+PRSERVER_LOG="${PRSERVER_DATA}/prserv.log"
+PRSERVER_HOST=${PRSERVER_HOST:-0.0.0.0}
+PRSERVER_POST=${PRSERVER_PORT:-8585}
+prserver_pidfile="/tmp/PRServer_${PRSERVER_HOST}_${PRSERVER_PORT}.pid"
+
+touch "${PRSERVER_LOG}"
+
+stop_server() {
+	start-stop-daemon --stop \
+		--oknodo \
+		--pidfile "${prserver_pidfile}" \
+		--remove-pidfile \
+	""
+	trap - SIGINT SIGTERM
+}
+
+start_server() {
+	echo "INFO: Starting PR server on ${PRSERVER_HOST}:${PRSERVER_PORT}"
+	local loglevel_args="--loglevel=INFO"
+	[ "${VERBOSE}" == true ] && loglevel_args="--loglevel=DEBUG"
+
+	start-stop-daemon --start \
+		--startas /srv/bitbake/bin/bitbake-prserv \
+		--oknodo \
+		--pidfile "${prserver_pidfile}" \
+		--user bitbake \
+		python /srv/bitbake/bin/bitbake-prserv \
+		-- \
+			--start \
+			--file="${PRSERVER_DATA}/prserv.sqlite3" \
+			--log="${PRSERVER_LOG}" \
+			${loglevel_args} \
+			--host=${PRSERVER_HOST} \
+			--port=${PRSERVER_PORT} \
+	""
+	trap stop_server SIGINT SIGTERM
+}
+
+stop_server
+start_server
+
+# Print diagnostic info
+ps aux
+
+# Monitor the pr-server log file and use it as the loop which keeps this init
+# process alive until the pr-server is done.
+read prserver_pid <"${prserver_pidfile}"
+tail --pid=${prserver_pid} -f ${PRSERVER_LOG} -n 0 &
+wait $!
+
+stop_server

--- a/scripts/azdo/pr-server/pr-server.Dockerfile
+++ b/scripts/azdo/pr-server/pr-server.Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3
+
+ARG PRSERVER_BB_REF=master
+ARG PRSERVER_BB_REMOTE=git://git.openembedded.org/bitbake
+
+
+# Create a `bitbake` user and group; which will actually run the server.
+RUN adduser \
+	--system \
+	--group \
+	--home /srv/bitbake \
+	--shell /bin/bash \
+	bitbake
+
+RUN install \
+	--mode=0775 \
+	--owner=bitbake \
+	--group=bitbake \
+	-d \
+		/srv/bitbake \
+		/var/pr-server
+
+COPY init.prserver.sh /init.prserver.sh
+
+USER bitbake
+
+RUN git clone \
+	--verbose \
+	--depth=1 \
+	--branch ${PRSERVER_BB_REF} \
+	${PRSERVER_BB_REMOTE} \
+	/srv/bitbake
+
+WORKDIR /srv/bitbake
+
+ENV PYTHONPATH=/srv/bitbake
+RUN python3 ./bin/bitbake-prserv --version
+ENTRYPOINT ["/bin/bash", "/init.prserver.sh"]

--- a/scripts/azdo/pr-server/pr-server.compose.yml
+++ b/scripts/azdo/pr-server/pr-server.compose.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+
+services:
+  pr-server:
+    build:
+      context: .
+      dockerfile: pr-server.Dockerfile
+      args:
+        PRSERVER_BB_REF: nilrt/master/hardknott
+        PRSERVER_BB_REMOTE: https://github.com/ni/bitbake
+    environment:
+      PRSERVER_HOST: 0.0.0.0
+      PRSERVER_PORT: 8585
+      VERBOSE: "false"
+    network_mode: host


### PR DESCRIPTION
    scripts: add pr-server docker container
    
    Add a docker container and compose spec which can be used to quickly
    standup a bitbake PatchRev server using an arbitary bitbake repo
    upstream ref.

----

This container is going to be useful when we eventually *kubernate* the natinst PR-server. But this is independently useful for external builders and developers, if they find themselves with a need to setup a particular version of the PR server.

## Testing
* When running on my dev machine, I can setup a sibling `nilrt-build` container and configure it with `PRSERV_HOST = "localhost:8585"`. Everything works as you would expect.

@ni/rtos 