### PR TITLE
scripts: add cve-to-csv.py script

### DIFF
--- a/scripts/dev/cve-to-csv.py
+++ b/scripts/dev/cve-to-csv.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+from pathlib import Path
+import os
+import sys
+
+
+parser = ArgumentParser(
+    description='Parses a directory full of OE cve_check stanza files, and writes thier csv equivalent to stdout.',
+    )
+parser.add_argument('cve_directory', type=Path,
+    help='Path to the cve_check output directory.'
+    )
+args = parser.parse_args()
+
+
+class CVE():
+
+    FIELDS = {
+        'LAYER': 'layer',
+        'PACKAGE NAME': 'package_name',
+        'PACKAGE VERSION': 'package_version',
+        'CVE': 'id',
+        'CVE STATUS': 'status',
+        'CVE SUMMARY': 'summary',
+        'CVSS v2 BASE SCORE': 'score_v2',
+        'CVSS v3 BASE SCORE': 'score_v3',
+        'VECTOR': 'vector',
+        'MORE INFORMATION': 'more_information',
+    }
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def from_stanza(stanza: str):
+        cve = CVE()
+        for line in stanza:
+            stanza_key, value = line.split(':', maxsplit=1)
+            value = value.strip()
+            if len(value) == 0:
+                value = None
+            attr_name = CVE.FIELDS[stanza_key]
+            setattr(cve, attr_name, value)
+        return cve
+
+    def to_csv(self, field_names):
+        values = []
+        for field_name in field_names:
+            value = getattr(self, field_name, '')
+            value = value.replace('"', '\'')
+            values.append(f'\"{value}\"')
+        return ','.join(values) + '\n'
+
+
+cves = []
+for root, dirs, fils in os.walk(args.cve_directory):
+    for fil in fils:
+        if fil.startswith('.'):
+            continue  # skip hidden files
+        sys.stderr.write(f'Processing CVE file: {fil} ')
+        cve_file = os.path.join(root, fil)
+        with open(cve_file, 'r') as fp_cve:
+            stanza_lines = []
+            for line in fp_cve.readlines():
+                line = line.strip()
+                if len(line) > 0:
+                    stanza_lines.append(line)
+                elif len(stanza_lines) > 0:
+                    new_cve = CVE.from_stanza(stanza_lines)
+                    sys.stderr.write('.')
+                    cves.append(new_cve)
+                else:
+                    continue
+        sys.stderr.write('\n')
+
+
+csv_headers = [f'"{x}"' for x in CVE.FIELDS.values()]
+sys.stdout.write(','.join(csv_headers) + '\n')
+for cve in cves:
+    sys.stdout.write(cve.to_csv(CVE.FIELDS.values()))


### PR DESCRIPTION
The cve_check class in OE will produce a directory of information about
what reported CVEs are outstanding in the layer stack. The CVE files are
presented in plain-text stanzas, which are not very easy to sort and
filter.

cve-to-csv.py will automatically digest the cve_check directory into a
comma separated value data structure - which it writes to stdout.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>