### PR TITLE
ni-oe-init-build-env: autocalculate BB_NUMBER_THREADS

### DIFF
--- a/ni-oe-init-build-env
+++ b/ni-oe-init-build-env
@@ -21,9 +21,21 @@ BITBAKEDIR=${BITBAKEDIR:-${SCRIPT_ROOT}/sources/bitbake}
 BUILDDIR=${BUILDDIR:-${SCRIPT_ROOT}/build}
 
 BB_ENV_EXTRAWHITE="${BB_ENV_EXTRAWHITE} \
+	BB_NUMBER_THREADS \
 	ENABLE_BUILD_TAG_PUSH \
 	GIT_REPODIR \
 "
+
+# Users can assert the maximum number of concurrent bitbake threads via the
+# BB_NUMBER_THREADS variable, or let this script calculate a reasonable value
+# based on the number of cores.
+if [ -z "$BB_NUMBER_THREADS" ]; then
+	echo "INFO: BB_NUMBER_THREADS not set. Calculating..."
+	# num_cores * 2 is the recommended value from the yocto manual
+	BB_NUMBER_THREADS=$(($(nproc) * 2))
+fi
+export BB_NUMBER_THREADS
+echo "BB_NUMBER_THREADS=${BB_NUMBER_THREADS}"
 
 # Define GIT_REPODIR as the directory containing the OE layer submodule repos.
 # This variable is used by the bblayers.conf file.


### PR DESCRIPTION
The BB_NUMBER_THREADS variable determines the maximum number of bitbake
tasks which are allowed to execute contemporaneously.

If the user asserts a value for this variable, pass it through to
bitbake. Otherwise, calculate the value by doubling the core count -
which is the recommended rule of thumb from the yocto manual.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

`nproc` is part of the `coreutils` package on most distros - so I consider this to be pretty safe. If `nproc` is not available for some reason, the command (and script) will fail and say as much.

The default value for this variable in OE is set to the core count (x1), by bitbake.conf.
```
#   set? /mnt/workspace/sources/openembedded-core/meta/conf/bitbake.conf:802
#     "${@oe.utils.cpu_count()}"
```

When you execute the script, output looks like this:
```bash
INFO: BB_NUMBER_THREADS not set. Calculating...
BB_NUMBER_THREADS=8
```

## Testing
Tested on my local hardknott docker containers.

@ni/rtos 