### PR TITLE
ni-org.conf: set opkg feed URI to external

### DIFF
--- a/scripts/azdo/conf/ni-org.conf
+++ b/scripts/azdo/conf/ni-org.conf
@@ -16,4 +16,4 @@ PRSERV_HOST = "versionator.amer.corp.natinst.com:8585"
 #
 # Internal feed configuration.
 #
-NILRT_FEEDS_URI ?= "http://nickdanger.amer.corp.natinst.com/feeds"
+#NILRT_FEEDS_URI ?= "http://nickdanger.amer.corp.natinst.com/feeds"


### PR DESCRIPTION
Comment out the internal feed URI set operation to allow the external
URI applied in meta-nilrt:conf/distro/nilrt.inc to stick.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>