### PR TITLE
ni-oe-init-build-env: Check out submodules if we haven't already

### DIFF
--- a/ni-oe-init-build-env
+++ b/ni-oe-init-build-env
@@ -145,6 +145,11 @@ pyrex_cleanup() {
 	unset PYREX_OEINIT PYREX_ROOT PYREX_TEMP_ENV_FILE pyrex_cleanup
 }
 
+# If user hasn't checked out submodules, do that now.
+if [ ! -f "$PYREX_OEINIT" ]; then
+	git submodule init
+	git submodule update --remote --checkout
+fi
 
 # Do some initial setup on the build directory
 if $enable_ni_org_conf; then


### PR DESCRIPTION
This is in the README, but this step is easy to forget to do. Make the script do it, if needed.