### PR TITLE
build.vms: remove remaining uuid references

### DIFF
--- a/scripts/pipelines/build.vms.sh
+++ b/scripts/pipelines/build.vms.sh
@@ -192,9 +192,6 @@ write_vm_startup_script() {
 	local script_destination_path=$2
 	local primary_disk=$3
 
-	local vm_uuid=$(uuidgen)
-	local disk_uuid=""
-
 	install \
 		--mode=0755 \
 		"${SCRIPT_RESOURCE_DIR}/${script_template}" \

--- a/scripts/pipelines/build.vms.sh
+++ b/scripts/pipelines/build.vms.sh
@@ -182,7 +182,7 @@ create_answers_iso() {
 
 error_and_die () {
 	log ERROR $1
-    exit 1
+	exit 1
 }
 
 # Copies a vm startup script template from the resource directory into the CWD,
@@ -200,8 +200,8 @@ write_vm_startup_script() {
 		"${SCRIPT_RESOURCE_DIR}/${script_template}" \
 		"./${script_destination_path}"
 
-    sed -i "s%\${PRIMARY_DISK}%${primary_disk}%g" "${script_destination_path}"
-    sed -i "s%\${VM_MEM_SIZE_MB}%${memory_mb}%g" "${script_destination_path}"
+	sed -i "s%\${PRIMARY_DISK}%${primary_disk}%g" "${script_destination_path}"
+	sed -i "s%\${VM_MEM_SIZE_MB}%${memory_mb}%g" "${script_destination_path}"
 }
 
 


### PR DESCRIPTION
The `vm_uuid` and `disk_uuid` variables are obsolete and place a requirement on the build host to have the `uuidgen` binary. Remove them.

# Testing
* With this patchset, I can now build the virtual machines using the relatively minimal nicentral container in my dev machine. The rfmibuild machines should be similar.

@ni/rtos 