### PR TITLE
scripts/azdo: do not attempt to use KVM on build machines

### DIFF
--- a/scripts/azdo/conf/pyrex.ini
+++ b/scripts/azdo/conf/pyrex.ini
@@ -110,8 +110,6 @@ envvars =
 # Extra arguments to pass when running the image. For example:
 #   --mount type=bind,src=${env:HOME}/.ssh,dst=${env:HOME}/.ssh,readonly
 #   --device /dev/kvm
-args =
-	--device /dev/kvm
 
 # Prefix for all Pyrex commands. Useful for debugging. For example:
 #   strace -ff -ttt -o strace.log --


### PR DESCRIPTION
The RFMIbuild machines apparently do not provide a /dev/kvm device for
docker to passthrough to the pyrex container. Remove the `/dev/kvm`
device from the AZDO pyrex.ini.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

This fix should resolve [this AZDO build error](https://dev.azure.com/ni/DevCentral/_build/results?buildId=1808168&view=logs&j=0a193208-2924-5e55-06a9-443a0d06402c&t=cf79e1af-511a-5af7-3dca-9986ee785f38&l=1078).

# Testing
Must test using the PR builds.

@ni/rtos 