### PR TITLE
Improve the build.extra-feeds.sh pipeline script

### DIFF
--- a/scripts/pipelines/build.extra-feeds.sh
+++ b/scripts/pipelines/build.extra-feeds.sh
@@ -17,6 +17,8 @@ EOF
 	exit ${1:-2}
 }
 
+core_feed_path=""
+
 positionals=()
 while [ $# -ge 1 ]; do case "$1" in
 	-h|--help)
@@ -36,7 +38,9 @@ esac; done
 # variable as a part of their native arg-parsing.
 # core_feed_path must be absolute here, because entering the pyrex build env
 # will switch the CWD.
-core_feed_path="$(realpath ${positionals[0]})"
+if [ ${#positionals[@]} -gt 0 ]; then
+	core_feed_path="$(realpath ${positionals[0]})"
+fi
 
 
 ## MAIN

--- a/scripts/pipelines/build.extra-feeds.sh
+++ b/scripts/pipelines/build.extra-feeds.sh
@@ -46,7 +46,7 @@ core_feed_path="$(realpath ${positionals[0]})"
 echo "INFO: Building the extra package feed."
 set -x
 bitbake packagegroup-ni-desirable
-bitbake --continue packagegroup-ni-extra
+bitbake --continue packagegroup-ni-extra || true
 set +x
 
 # If the user provided a core/ feed path, dedupe against it.

--- a/scripts/pipelines/build.extra-feeds.sh
+++ b/scripts/pipelines/build.extra-feeds.sh
@@ -7,22 +7,33 @@ DELETE_DUPLICATE_IPKS="bash ${SCRIPT_ROOT}/delete-duplicate-ipks.sh"
 ## ARGUMENT PARSING
 usage() {
 	cat <<EOF
-$(basename $BASH_SOURCE) [CORE_FEED_PATH]
+$(basename $BASH_SOURCE) [--help] [--no-index] [CORE_FEED_PATH]
+
 Builds the NILRT extra/ package feed. If CORE_FEED_PATH is asserted, also
 remove any packages from the extras feed which is already in core/.
 
-Positionals:
-CORE_FEED_PATH  Filepath to the root of the NILRT core/ IPK feed.
+# Options
+-n, --no-index
+  If asserted, skip creating the package-index at the end of feed generation.
+
+# Positional Arguments
+CORE_FEED_PATH
+	Filepath to the root of the NILRT core/ IPK feed.
 EOF
 	exit ${1:-2}
 }
 
+skip_package_index=false
 core_feed_path=""
 
 positionals=()
 while [ $# -ge 1 ]; do case "$1" in
 	-h|--help)
 		usage 0
+		;;
+	-n|--no-index)
+		skip_package_index=true
+		shift
 		;;
 	-*|--*)
 		echo "ERROR: unknown option: $1" >&2
@@ -64,5 +75,9 @@ if [ -n "${core_feed_path}" ]; then
 fi
 
 # Package index generation must happen after we have deduped IPKs.
-echo "INFO: Generating extra/ feed indexes."
-bitbake package-index
+if [ "$skip_package_index" != true ]; then
+	echo "INFO: Generating extra/ feed indexes."
+	bitbake package-index
+else
+	echo "INFO: Skipping package index generation by user request."
+fi


### PR DESCRIPTION
The `-extra` feed build pipeline is currently failing due to anticipated errors in the extra feed recipes. As a matter of policy, we allow these errors and do not expect them to break the build.

This PR:
1. Updates the extra feed pipeline script to allow for errors in `packagegroup-ni-extra` itself.
2. Fixes a script bug where the script would error if the `CORE_FEED_PATH` positional argument was not supplied.
3. Adds a new option to the script to skip the lengthy `bitbake package-index` step. (useful for debugging)

# Testing
Substituted the `-desirable` and `-extra` packagegroups for quicker BB targets and ran on my dev machine. This new logic seems to work well and the script not error spuriously.

@ni/rtos 