### PR TITLE
pipelines: add process-buildstats.sh script

### DIFF
--- a/scripts/pipelines/process-buildstats.sh
+++ b/scripts/pipelines/process-buildstats.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -euo pipefail
+
+
+## CONSTANTS
+SCRIPT_ROOT=$(realpath $(dirname ${BASH_SOURCE}))
+PYBOOTCHARTGUI="python3 ${SCRIPT_ROOT}/../../sources/openembedded-core/scripts/pybootchartgui/pybootchartgui.py"
+
+# Channels which are only printed when verbose
+LOG_VERBOSEONLY_CHANNELS=(DEBUG INFO)
+log() {
+	local log_level=$1
+	local log_msg=${@:2}
+	if [[ "${LOG_VERBOSEONLY_CHANNELS[@]}" == *"$log_level"* \
+		&& "${verbose:-}" != true ]]; then
+		return
+	else
+		echo "${log_level}:" $log_msg >&2
+	fi
+}
+
+
+## CLI PARSING
+usage() {
+	cat <<EOF
+$(basename ${BASH_SOURCE}) [--help] [--verbose] \\
+	BUILDSTATS_DIRECTORY
+
+# TODO: Program Description here
+
+# Options
+-h, --help
+    Print this usage information and exit.
+-v, --verbose
+    Print all log channels during execution.
+
+# Positional Arguments
+BUILDSTATS_DIRECTORY
+    Filepath to the buildstats directory which should be processed.
+
+# Environmentals
+
+# Returns
+EOF
+}
+
+
+buildstats_dir=
+positionals=()
+verbose=false
+
+while [ $# -ge 1 ]; do case "$1" in
+	-h|--help)
+		usage
+		exit 0
+		;;
+	-v|--verbose)
+		verbose=true
+		shift
+		;;
+	-*|--*)
+		log ERROR "Invalid or unknown option \"$1\"."
+		exit 2
+		;;
+	*)
+		positionals+=($1)
+		shift
+		;;
+esac; done
+
+if [ ${#positionals[@]} -lt 1 ]; then
+	log ERROR "Missing required positional arguments.";
+	usage
+	exit 2
+fi
+buildstats_dir=${positionals[0]}
+log INFO "Processing buildstats directory: $buildstats_dir"
+
+
+## MAIN
+$PYBOOTCHARTGUI -o "${buildstats_dir}/chart_resources" -M -T -m 999999 -f svg "${buildstats_dir}"


### PR DESCRIPTION
The openembedded-core layer comes with a modified `bootchart`
implementation which is capable of processing the output from the
buildstats.bbclass.

`process-buildstats.sh` is a script entrypoint to post-process this data
into an SVG file displaying resource information (eg. CPU, memory, disk
usage) throughout the build.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>


Example output looks like this:

![chart_resources](https://user-images.githubusercontent.com/10503146/148598858-23d01063-88da-4a31-a59c-503fcf6c1490.png)

# Testing
Tested on my dev machine with an arbitrary build where I have `INHERIT += "buildstats"` asserted in my `local.conf`.

@ni/rtos 