### PR TITLE
pipelines: update feed recipe names

### DIFF
--- a/scripts/pipelines/build.core-feeds.sh
+++ b/scripts/pipelines/build.core-feeds.sh
@@ -5,5 +5,5 @@ SCRIPT_ROOT=$(realpath $(dirname $BASH_SOURCE))
 . "${SCRIPT_ROOT}/build.common.sh"
 
 echo "INFO: Building the core package feed."
-bitbake packagegroup-ni-coreimagerepo
+bitbake packagefeed-ni-core
 bitbake package-index

--- a/scripts/pipelines/build.extra-feeds.sh
+++ b/scripts/pipelines/build.extra-feeds.sh
@@ -61,7 +61,7 @@ fi
 echo "INFO: Building the extra package feed."
 set -x
 bitbake packagegroup-ni-desirable
-bitbake --continue packagegroup-ni-extra || true
+bitbake --continue packagefeed-ni-extra || true
 set +x
 
 # If the user provided a core/ feed path, dedupe against it.


### PR DESCRIPTION
The "core" and "extra" package feeds in meta-nilrt have been renamed
from packagegroup-ni-${feed} to packagefeed-ni-${feed}. Update their
names in the pipeline scripts.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>