### PR TITLE
build.vms.sh: update NILRT recovery media recipe name

### DIFF
--- a/scripts/pipelines/build.vms.sh
+++ b/scripts/pipelines/build.vms.sh
@@ -41,7 +41,7 @@ Create a NILRT virtual machine archive (QEMU).
 EOF
 }
 
-RECOVERY_IMAGE_RECIPE_NAME=nilrt-recovery-image
+RECOVERY_IMAGE_RECIPE_NAME=nilrt-recovery-media
 PYREX_RUN=pyrex-run
 
 DEFAULT_IMAGES_DIR="./tmp-glibc/deploy/images/x64"


### PR DESCRIPTION
The NILRT recovery media recipe has changed names in meta-nilrt.

Update the default media name in the build.vms script, so that it will
pull the correct artifact.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

@ni/rtos 