### PR TITLE
dist-feed: update 21.8 dist feed

### DIFF
--- a/scripts/jenkins/dist-feed/dist-feed-manifest.yml
+++ b/scripts/jenkins/dist-feed/dist-feed-manifest.yml
@@ -116,16 +116,10 @@ packages:
     ipk_path: 'targets/linuxU/x64/gcc-4.7-oe/release/onert_system_image_ipk_pxi/dist-nilrt-grub_*.ipk'
   dist-nilrt-grub_21.8_arm:
     export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/21.8') | latest_export }}"
-    ipk_path: 'targets/linuxU/armv7-a/gcc-4.7-oe/release/onert_system_image_ipk_default/dist-nilrt-grub_*.ipk'
+    ipk_path: 'targets/linuxU/armv7-a/gcc-4.7-oe/release/onert_system_image_ipk/dist-nilrt-grub_*.ipk'
   dist-nilrt-grub_21.8_x64:
     export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/21.8') | latest_export }}"
-    ipk_path: 'targets/linuxU/x64/gcc-4.7-oe/release/onert_system_image_ipk_default/dist-nilrt-grub_*.ipk'
-  dist-nilrt-grub_21.8_x64-combo:
-    export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/21.8') | latest_export }}"
-    ipk_path: 'targets/linuxU/x64/gcc-4.7-oe/release/onert_system_image_ipk_combo/dist-nilrt-grub_*.ipk'
-  dist-nilrt-grub_21.8_x64-pxi:
-    export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/21.8') | latest_export }}"
-    ipk_path: 'targets/linuxU/x64/gcc-4.7-oe/release/onert_system_image_ipk_pxi/dist-nilrt-grub_*.ipk'
+    ipk_path: 'targets/linuxU/x64/gcc-4.7-oe/release/onert_system_image_ipk/dist-nilrt-grub_*.ipk'
   dist-nilrt-systemlink-grub_19.6_arm-crio:
     export: "{{ (((MNT_NIRVANA_PERFORCEEXPORTS + '/MAX/sysmgmt/installers/current_gen/skyline_rt_client_runtime/export/19.6') | latest_export) + '/.archives/linux.zip') | unzip }}"
     ipk_path: 'targets/linuxU/armv7-a/gcc-4.9-oe/release/dist_nilrt_systemlink_grub_ipk/dist-nilrt-systemlink-grub_*.ipk'


### PR DESCRIPTION
The "default", "combo" and "pxi" variants for this IPK have been condensed back down to a single version, which means that recent 21.8 exports no longer have those files in them for us to grab.

Fixes AzDO#1835094.

Tested by running `make dist-feed`.