### PR TITLE
ni-org.conf: disable versionator

### DIFF
--- a/scripts/azdo/conf/ni-org.conf
+++ b/scripts/azdo/conf/ni-org.conf
@@ -11,7 +11,7 @@ SOURCE_MIRROR_URL ?= "http://git.amer.corp.natinst.com/snapshots"
 
 # The network based PR service host and port Set PRSERV_HOST to 'localhost:0'
 # to automatically start local PRService.
-PRSERV_HOST = "versionator.amer.corp.natinst.com:8585"
+#PRSERV_HOST = "versionator.amer.corp.natinst.com:8585"
 
 #
 # Internal feed configuration.


### PR DESCRIPTION
Temporarily stop using the 'versionator' PR server, while it is
experiencing downtime.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

I'll revert this PR, once versionator is back online.

# Testing

Ran `bitbake -e glibc`, which would hang if the pr-server doesn't respond.

@ni/rtos 