### PR TITLE
[hardknott] Revert "ni-org.conf: disable versionator"

### DIFF
--- a/scripts/azdo/conf/ni-org.conf
+++ b/scripts/azdo/conf/ni-org.conf
@@ -11,7 +11,7 @@ SOURCE_MIRROR_URL ?= "http://git.amer.corp.natinst.com/snapshots"
 
 # The network based PR service host and port Set PRSERV_HOST to 'localhost:0'
 # to automatically start local PRService.
-#PRSERV_HOST = "versionator.amer.corp.natinst.com:8585"
+PRSERV_HOST = "versionator.amer.corp.natinst.com:8585"
 
 #
 # Internal feed configuration.


### PR DESCRIPTION
This reverts commit be2ca81906cfa2de782753eca3392490621394bf.

----

The `versionator` server is back online, and the workaround a put in yesterday can be removed.

# Testing
`bitbake -e glibc` doesn't timeout waiting for the versionator server.

@ni/rtos 