### PR TITLE
Adding DCO to CONTRIBUTING

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -72,3 +72,36 @@ At a minimum, you should add an additional message trailer declaring the upstrea
 #### .patch file names
 
 When bitbake applies `.patch` files to a recipe, it copies all `.patch` files into the recipe's workspace, then applies them in alphanumeric-order. In your PR, be mindful of how your `.patch` file is ordered versus the other files in the recipe. Keep in mind that some `.patch` files might come from other layers.
+
+## Developer Certificate of Origin (DCO)
+
+   Developer's Certificate of Origin 1.1
+
+   By making a contribution to this project, I certify that:
+
+   (a) The contribution was created in whole or in part by me and I
+       have the right to submit it under the open source license
+       indicated in the file; or
+
+   (b) The contribution is based upon previous work that, to the best
+       of my knowledge, is covered under an appropriate open source
+       license and I have the right under that license to submit that
+       work with modifications, whether created in whole or in part
+       by me, under the same open source license (unless I am
+       permitted to submit under a different license), as indicated
+       in the file; or
+
+   (c) The contribution was provided directly to me by some other
+       person who certified (a), (b) or (c) and I have not modified
+       it.
+
+   (d) I understand and agree that this project and the contribution
+       are public and that a record of the contribution (including all
+       personal information I submit with it, including my sign-off) is
+       maintained indefinitely and may be redistributed consistent with
+       this project or the open source license(s) involved.
+
+(taken from [developercertificate.org](https://developercertificate.org/))
+
+See [COPYING.MIT](https://github.com/ni/nilrt/blob/HEAD/COPYING.MIT)
+for details about how nilrt is licensed.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,11 +19,6 @@ Current Project Maintainers:
 
 To support rolling product development, NILRT frequently maintains multiple mainline development branches, each rebased upon a different OE upstream stable release. The mainline branch refs are namespaced like `nilrt/master/${oe_stable}`. The mainline branches are generally open to contribution until they reach the end of their life.
 
-Status | NI Release | NILRT Version | Branch Ref
--------|------------|---------------|-----------
-Open | 21.X  | 9.X | [nilrt/master/dunfell](https://github.com/ni/nilrt/tree/nilrt/master/dunfell)
-Open | 20.X  | 8.X | [nilrt/master/sumo](https://github.com/ni/nilrt/tree/nilrt/master/sumo)
-
 NILRT follows a mainline-branch model. Near a release, the project maintainers create a product branch for stable production builds. The branches are named `nilrt/${ni_release}/${oe_stable}` like `nilrt/20.6/sumo`, and are only open to necessary bug fixes and security backports relevant to the product release.
 
 


### PR DESCRIPTION
Adding Developer Certificate of Origin to CONTRIBUTING.md and removing the branch-specific information from the branches section.

Signed-off-by: Charlie Johnston [charlie.johnston@ni.com](mailto:charlie.johnston@ni.com)

@ni/rtos 