### PR TITLE
[hardknott] gitmodules: remove meta-ivi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,10 +58,6 @@
 	path = sources/meta-qt5-extra
 	url = ../meta-qt5-extra.git
 	branch = nilrt/master/hardknott
-[submodule "sources/meta-ivi"]
-	path = sources/meta-ivi
-	url = ../meta-ivi.git
-	branch = nilrt/master/hardknott
 [submodule "sources/meta-rauc"]
 	path = sources/meta-rauc
 	url = ../meta-rauc.git


### PR DESCRIPTION
The meta-ivi repo is dead upstream and no longer supported by
meta-nilrt.

Remove it from the submodules.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

[meta-nilrt #347](https://github.com/ni/meta-nilrt/pull/347) removes the meta-ivi layer from our bblayers.conf.

NI AZDO: [Technical Debt 1769944](https://dev.azure.com/ni/DevCentral/_workitems/edit/1769944)

# Testing
N/A

@ni/rtos 