### PR TITLE
Removing meta-java from submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,10 +42,6 @@
 	path = sources/meta-sdr
 	url = ../meta-sdr.git
 	branch = nilrt/master/hardknott
-[submodule "sources/meta-java"]
-	path = sources/meta-java
-	url = ../meta-java.git
-	branch = nilrt/master/hardknott
 [submodule "sources/meta-measured"]
 	path = sources/meta-measured
 	url = ../meta-measured.git


### PR DESCRIPTION
Removing meta-java from submodules

The upstream meta-java layer is dead, and we have not seen
any recent downloads. Removing this layer for now.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1779137

### Testing
Ran `bitbake packagefeed-ni-core` and confirmed successful build.

Ran `bitbake --parse-only packagefeed-ni-extra`
```
charlie@cjohnsto-debian-dev:~/nilrt/build$ bitbake --parse-only packagefeed-ni-extra
Loading cache: 100% |############################################| Time: 0:00:00
Loaded 5380 entries from dependency cache.
Parsing recipes: 100% |##########################################| Time: 0:00:01
Parsing of 3933 .bb files complete (3925 cached, 8 parsed). 5388 targets, 177 skipped, 1 masked, 0 errors.
```