### PR TITLE
Updating RTOS email in CONTRIBUTING to be more generic and future-proof.

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,7 +12,7 @@ The OE-layers used by the project are also available under the [github.com/ni](h
 Current Project Maintainers:
 * Alex Stewart <[alex.stewart@ni.com](mailto:alex.stewart@ni.com)> [[Github](https://github.com/amstewart)]
 * Shruthi Ravichandran <[shruthi.ravichandran@ni.com](mailto:shruthi.ravichandran@ni.com)> [[Github](https://github.com/shruthi-ravi)]
-* The NI RTOS Team <[dsw.rtos@ni.com](mailto:dsw.rtos@ni.com)>
+* The NI RTOS Team <[RTOS@ni.com](mailto:RTOS@ni.com)>
 
 
 ### Branches


### PR DESCRIPTION
Updating RTOS email in CONTRIBUTING to be more generic and future-proof.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

We have a new contact email that's more genericized and future proof (RTOS@ni.com). This change updates CONTRIBUTING.md to use the new email address and hopefully remove the need for future updates to the team email.