### PR TITLE
Removing meta-mono due to lack of usage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,10 +26,6 @@
 	path = sources/meta-mingw
 	url = ../meta-mingw.git
 	branch = nilrt/master/hardknott
-[submodule "sources/meta-mono"]
-	path = sources/meta-mono
-	url = ../meta-mono.git
-	branch = nilrt/master/hardknott
 [submodule "sources/meta-virtualization"]
 	path = sources/meta-virtualization
 	url = ../meta-virtualization.git


### PR DESCRIPTION
Dropping support for meta-mono due to cost of maintenance
and lack of interest in using the packages contained therein.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Link: https://dev.azure.com/ni/DevCentral/_workitems/edit/1599057/

## Testing:
```
charlie@cjohnsto-debian-dev:~/nilrt/build$ bitbake --parse-only packagegroup-ni-base
Loading cache: 100% |###########################################################| Time: 0:00:00
Loaded 5198 entries from dependency cache.
Parsing recipes: 100% |#########################################################| Time: 0:00:01
Parsing of 3760 .bb files complete (3752 cached, 8 parsed). 5206 targets, 177 skipped, 1 masked, 0 errors.
```