### PR TITLE
Removing the meta-mingw layer from NI Linux Real-Time

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,10 +22,6 @@
 	path = sources/openembedded-core
 	url = ../openembedded-core.git
 	branch = nilrt/master/hardknott
-[submodule "sources/meta-mingw"]
-	path = sources/meta-mingw
-	url = ../meta-mingw.git
-	branch = nilrt/master/hardknott
 [submodule "sources/meta-virtualization"]
 	path = sources/meta-virtualization
 	url = ../meta-virtualization.git


### PR DESCRIPTION
Removing meta-mingw layer

The meta-mingw layer adds support for SDK cross-compiling
on Windows. This requirement has been dropped.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

Azure Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1599057/

##Testing:
```
(bb) charlie@cjohnsto-debian-dev:~/nilrt/build$ bitbake --parse-only packagegroup-ni-base
Loading cache: 100% |                                           | ETA:  --:--:--
Loaded 0 entries from dependency cache.
WARNING: /home/charlie/nilrt/sources/meta-selinux/recipes-security/refpolicy/refpolicy-targeted_git.bb: Unable to get checksum for refpolicy-targeted SRC_URI entry refpolicy-fix-optional-issue-on-sysadm-module.patch: file could not be found
WARNING: /home/charlie/nilrt/sources/meta-selinux/recipes-security/refpolicy/refpolicy-targeted_git.bb: Unable to get checksum for refpolicy-targeted SRC_URI entry refpolicy-unconfined_u-default-user.patch: file could not be found
Parsing recipes: 100% |##########################################| Time: 0:00:39
Parsing of 3928 .bb files complete (0 cached, 3928 parsed). 5382 targets, 172 skipped, 1 masked, 0 errors.

Summary: There were 2 WARNING messages shown.
```