### PR TITLE
cherry-pick: remove submodule meta-measured as it is dead upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,10 +34,6 @@
 	path = sources/meta-sdr
 	url = ../meta-sdr.git
 	branch = nilrt/21.8/hardknott
-[submodule "sources/meta-measured"]
-	path = sources/meta-measured
-	url = ../meta-measured.git
-	branch = nilrt/21.8/hardknott
 [submodule "sources/meta-qt5"]
 	path = sources/meta-qt5
 	url = ../meta-qt5.git


### PR DESCRIPTION
Signed-off-by: Jerry Xie <jerry.xie@ni.com>
(cherry picked from commit 2a6d017fd8f5765127f6a5d1fa597850eca36977)