### PR TITLE
dist-feed: Use 22.0 ipk from official exports

### DIFF
--- a/scripts/jenkins/dist-feed/dist-feed-manifest.yml
+++ b/scripts/jenkins/dist-feed/dist-feed-manifest.yml
@@ -121,7 +121,7 @@ packages:
     export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/21.8') | latest_export }}"
     ipk_path: 'targets/linuxU/x64/gcc-4.7-oe/release/onert_system_image_ipk/dist-nilrt-grub_*.ipk'
   dist-nilrt-grub_22.0_x64:
-    export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/prototype/export/22.0') | latest_export }}"
+    export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/22.0') | latest_export }}"
     ipk_path: 'targets/linuxU/x64/gcc-4.7-oe/release/onert_system_image_ipk/dist-nilrt-grub_*.ipk'
   dist-nilrt-systemlink-grub_19.6_arm-crio:
     export: "{{ (((MNT_NIRVANA_PERFORCEEXPORTS + '/MAX/sysmgmt/installers/current_gen/skyline_rt_client_runtime/export/19.6') | latest_export) + '/.archives/linux.zip') | unzip }}"


### PR DESCRIPTION
Switch from prototype to official exports as they're available now.

### Testing
None