### PR TITLE
Updating SOURCE_MIRROR_URL to internal argo location

### DIFF
--- a/scripts/azdo/conf/ni-org.conf
+++ b/scripts/azdo/conf/ni-org.conf
@@ -7,7 +7,7 @@
 #
 INHERIT += "own-mirrors"
 BB_GENERATE_MIRROR_TARBALLS = "1"
-SOURCE_MIRROR_URL ?= "http://git.amer.corp.natinst.com/snapshots"
+SOURCE_MIRROR_URL ?= "http://argohttp.natinst.com/RTOS/oe-source-mirror/"
 
 # The network based PR service host and port Set PRSERV_HOST to 'localhost:0'
 # to automatically start local PRService.


### PR DESCRIPTION
Changing OE SOURCE_MIRROR_URL to new internal argo mirror.

We've changed our internal premirror to a new location.
This new mirror updates anytime a package has to be
fetched externally.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO Work Item: https://ni.visualstudio.com/DevCentral/_workitems/edit/1902432/

## Testing
Ran `bitbake -DDD -c fetch openvpn` and checked the output for the following:
```
DEBUG: openvpn-2.5.2-r0 do_fetch: Fetching http://argohttp.natinst.com/RTOS/oe-source-mirror/openvpn-2.5.2.tar.gz using command '/usr/bin/env wget -t 2 -T 30 --passive-ftp --no-check-certificate -P /home/charlie/nilrt/build/downloads 'http://argohttp.natinst.com/RTOS/oe-source-mirror/openvpn-2.5.2.tar.gz''
DEBUG: openvpn-2.5.2-r0 do_fetch: Fetcher accessed the network with the command /usr/bin/env wget -t 2 -T 30 --passive-ftp --no-check-certificate -P /home/charlie/nilrt/build/downloads 'http://argohttp.natinst.com/RTOS/oe-source-mirror/openvpn-2.5.2.tar.gz'
```