### PR TITLE
[sumo] Support pyrex

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,3 +66,6 @@
 	path = sources/meta-rauc
 	url = ../meta-rauc.git
 	branch = nilrt/master/sumo
+[submodule "sources/pyrex"]
+	path = sources/pyrex
+	url = ../pyrex.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -69,3 +69,4 @@
 [submodule "sources/pyrex"]
 	path = sources/pyrex
 	url = ../pyrex.git
+	branch = nilrt/master/sumo

--- a/docker/build-nilrt.Dockerfile
+++ b/docker/build-nilrt.Dockerfile
@@ -1,0 +1,11 @@
+ARG PYREX_IMAGE
+FROM ${PYREX_IMAGE} as build-nilrt
+
+# ISO and QEMU utilities are needed by the build.vm.sh pipeline scriptlet.
+RUN apt-get update && apt-get install --assume-yes \
+	genisoimage \
+	qemu-system-x86 \
+	qemu-utils \
+""
+
+# this Dockerfile layer contains nothing yet.

--- a/docker/create-build-nilrt.sh
+++ b/docker/create-build-nilrt.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -u
+
+SCRIPT_ROOT=$(realpath $(dirname ${BASH_SOURCE}))
+PYREX_ROOT=$(realpath "${SCRIPT_ROOT}/../sources/pyrex")
+PYREX_BASE=ubuntu-18.04-oe
+
+IMAGE_NAME=build-nilrt
+
+usage() {
+	cat >&2 <<EOF
+$(basename) [TAG_BRANCH]
+Creates a new build-nilrt container based on the garmin/pyrex containers, and
+tags it with the current nilrt.git repo shorthash, as 'latest', and
+(optionally) with the current OE branch name.
+
+Positionals:
+TAG_BRANCH  The 'branch' name of the current nilrt.git repo (eg. 'dunfell'). If
+            not set, the docker container will not be tagged with the branch
+            name.
+EOF
+	exit ${1:-2}
+}
+
+positionals=()
+while [ $# -ge 1 ]; do case "$1" in
+	-h|--help)
+		usage 0
+		;;
+	*)
+		positionals+=($1)
+		shift
+		;;
+esac
+done
+
+set -x
+
+# consume positionals
+tag_branch=${positionals[0]:-}
+
+
+# parse out the short git hash, to tag this image with the current commit
+pushd "${SCRIPT_ROOT}"
+short_hash=$(git rev-parse --short HEAD)
+popd
+
+
+set -e
+# build the pyrex base image
+docker build \
+	-f "${PYREX_ROOT}/image/Dockerfile" \
+	-t "pyrex-base:sumo" \
+	--build-arg=PYREX_BASE=$PYREX_BASE \
+	"${PYREX_ROOT}/image"
+
+# build the build-nilrt image
+docker build \
+	-f "${SCRIPT_ROOT}/build-nilrt.Dockerfile" \
+	-t "${IMAGE_NAME}:${short_hash}" \
+	--build-arg=PYREX_IMAGE=pyrex-base:sumo \
+	"${SCRIPT_ROOT}"
+
+# tag the image as 'latest'
+docker tag \
+	"${IMAGE_NAME}:${short_hash}" \
+	"${IMAGE_NAME}:latest"
+
+# optionally tag it with the branch name
+if [ -n "${tag_branch}" ]; then
+	docker tag \
+		"${IMAGE_NAME}:${short_hash}" \
+		"${IMAGE_NAME}:${tag_branch}"
+fi
+set +e

--- a/ni-oe-init-build-env
+++ b/ni-oe-init-build-env
@@ -2,57 +2,177 @@
 
 SCRIPT_ROOT=$(realpath $(dirname ${BASH_SOURCE:-${0}}))
 
+
+usage() {
+	cat >&2 <<EOF
+$(basename ${BASH_SOURCE}) [-h] [-o] \
+    [-s SSTATE_MIRROR_PREFIX SSTATE_MIRROR_PATH] \
+	[[--] OE_INIT_ARGS...]
+
+Arguments:
+-h, --help    Print this usage text and exit.
+-o, --org
+	Enable configurations which are only valid when the build host is connected
+	to the NI corporate network. Community builders should not use this
+    setting.
+-s, --sstate-mirror SSTATE_MIRROR_PREFIX SSTATE_MIRROR_PATH
+	Add the SSTATE_MIRROR_PREFIX/_PATH pair to the bitbake environment's
+    SSTATE_MIRRORS variable.
+
+Positionals:
+PYREX_ARGS    Arguments passed to pyrex.py as positional arguments.
+EOF
+}
+
 enable_ni_org_conf=false
+sstate_mirrors=()
 positionals=()
 
+set -u
 while [ $# -ge 1 ]; do case "$1" in
+	-d|--download-dir)
+		shift
+		export DL_DIR=$(realpath "$1")
+		shift
+		;;
+	-h|--help)
+		usage
+		return 0
+		;;
 	-o|--org)
 		enable_ni_org_conf=true
 		shift
+		;;
+	-s|--sstate-mirror)
+		if [ -z "${2:-}" -o -z "${3:-}" ]; then
+			echo "ERROR: --sstate-mirror argument expected two strings." >&2
+			return 2
+		fi
+		sstate_mirrors+=("$2 $3")
+		shift 3
+		;;
+	--)
+		shift
+		for positional in $@; do
+			positionals+=($positional)
+		done
+		break
+		;;
+	-*|--*)
+		echo "ERROR: Unknown script argument $1." >&2
+		return 2
 		;;
 	*)
 		positionals+=($1)
 		shift
 		;;
 esac; done
+set +u
+
+# Determine the OE build workspace path. We honor the user's BUILDDIR env
+# variable, unless it is undefined, or overwritten with positional arguments.
+if [ -n "${positionals[0]}" ]; then
+	BUILDDIR=${positionals[0]}
+	positionals=${positionals[@]:1}  # shift array
+elif [ -z "$BUILDDIR" ]; then
+	# if the user has expressed no preference, default to :build/
+	BUILDDIR="${SCRIPT_ROOT}/build"
+fi  # implicit-else: use the users's BUILDDIR value
+echo "INFO: Using ${BUILDDIR} as the OE build workspace."
 
 
-BITBAKEDIR=${BITBAKEDIR:-${SCRIPT_ROOT}/sources/bitbake}
-BUILDDIR=${BUILDDIR:-${SCRIPT_ROOT}/build}
+NILRT_ROOT="${SCRIPT_ROOT}"
 
-BB_ENV_EXTRAWHITE="${BB_ENV_EXTRAWHITE} \
-	ENABLE_BUILD_TAG_PUSH \
-	GIT_REPODIR \
-"
+# GIT_REPODIR is used by the meta-nilrt bblayers.conf to locate the BB layer
+# top-level directory.
+export GIT_REPODIR="${NILRT_ROOT}/sources"
 
-# Define GIT_REPODIR as the directory containing the OE layer submodule repos.
-# This variable is used by the bblayers.conf file.
-export GIT_REPODIR=${SCRIPT_ROOT}/sources
+# Enable color terminal by default
+export TERM=${TERM:-xterm-256color}
+
+BITBAKEDIR=${BITBAKEDIR:-${NILRT_ROOT}/sources/bitbake}
+
+## BITBAKE VARIABLES ##
+# Users can assert the maximum number of concurrent bitbake threads via the
+# BB_NUMBER_THREADS variable, or let this script calculate a reasonable value
+# based on the number of cores.
+if [ -z "${BB_NUMBER_THREADS:-}" ]; then
+	echo "INFO: BB_NUMBER_THREADS not set. Calculating..."
+	# num_cores * 2 is the recommended value from the yocto manual
+	BB_NUMBER_THREADS=$(($(nproc) * 2))
+fi
+export BB_NUMBER_THREADS
+echo "BB_NUMBER_THREADS=${BB_NUMBER_THREADS}"
 
 # define the location of bitbake configuration files, which will be copied
 # into the build workspace, if one needs to be created.
-TEMPLATECONF=${TEMPLATECONF:-${SCRIPT_ROOT}/sources/meta-nilrt/conf}
+export TEMPLATECONF=${TEMPLATECONF:-${NILRT_ROOT}/sources/meta-nilrt/conf}
 
-export TEMPLATECONF
+export SSTATE_MIRRORS="${SSTATE_MIRRORS:-} ${sstate_mirrors[@]/%/ \\n}"
 
-# Call OE-upstream's build env initialization script, which will create a build
-# workspace called either "${1:-build}/" and `cd` into it.
-cd ${SCRIPT_ROOT}
-. ./sources/openembedded-core/oe-init-build-env ${positionals[@]}
+# Define here all NILRT-specific variables which need to be passed to bitbake
+# (should include everything we've set above which is non-standard)
+export BB_ENV_EXTRAWHITE="${BB_ENV_EXTRAWHITE:-} \
+	BB_NUMBER_THREADS \
+	BUILDNAME \
+	DISTRO \
+	DL_DIR \
+	GIT_REPODIR \
+	IPK_FEED_URIS \
+	MACHINE \
+	NILRT_LOCAL_FEED_URI \
+	SSTATE_DIR \
+	SSTATE_MIRRORS \
+"
 
+
+## PYREX VARIABLES ###
+# Setup pyrex config variables
+export PYREXCONFFILE=${PYREXCONFFILE:-"${SCRIPT_ROOT}/pyrex.ini"}
+export PYREX_CONFIG_BIND="${NILRT_ROOT}"
+export PYREX_OEINIT="${NILRT_ROOT}/sources/openembedded-core/oe-init-build-env"
+export PYREX_ROOT="${NILRT_ROOT}/sources/pyrex"
+
+
+unset SCRIPT_ROOT
+
+if [ -z "${PYREX_TEMP_ENV_FILE:-}" ]; then
+	PYREX_TEMP_ENV_FILE=$(mktemp -t pyrex-env.XXXXXX)
+fi
+
+pyrex_cleanup() {
+	rm -f "$PYREX_TEMP_ENV_FILE"
+	unset PYREX_OEINIT PYREX_ROOT PYREX_TEMP_ENV_FILE pyrex_cleanup
+}
+
+
+# Do some initial setup on the build directory
 if $enable_ni_org_conf; then
-	if [ ! -e conf/site.conf ]; then
-		echo "Adding NI org.conf as conf/site.conf..."
-		cp ${SCRIPT_ROOT}/scripts/azdo/conf/ni-org.conf ./conf/site.conf
+	{
+		install -D --mode=0644 \
+			"${NILRT_ROOT}/scripts/azdo/conf/ni-org.conf" \
+			"${BUILDDIR}/conf/site.conf"
+	} || exit 1
 	fi
+
+
+# Invoke pyrex to: standup our build container and BB build directory, and to
+# "capture" the current shell within the pyrex toolchain context.
+"$PYREX_ROOT/pyrex.py" capture \
+		-a PYREX_OEINIT "$PYREX_OEINIT" \
+		-e PYREXCONFFILE \
+		-e TEMPLATECONF \
+		-- 9 "${BUILDDIR}" "${positionals[@]}" \
+		9> "$PYREX_TEMP_ENV_FILE"
+if [ $? -ne 0 ]; then
+	pyrex_cleanup
+	return 1
 fi
 
-# Add a marker to the prompt based on whether or not bitbake is in the
-# environment.
-if which bitbake >/dev/null; then
-	if [[ ! "${PS1}" =~ ^\(bb\).* ]]; then
-		export PS1="(bb) $PS1"
+. "$PYREX_TEMP_ENV_FILE"
+if [ $? -ne 0 ]; then
+	pyrex_cleanup
+	return 1
 	fi
-else
-	echo "ERROR: 'bitbake' command is not available in the environment."
-fi
+
+pyrex_cleanup

--- a/pyrex.ini
+++ b/pyrex.ini
@@ -1,0 +1,121 @@
+# Pyrex User Configuration
+#
+# The following variables are made available as variable expansions when
+# Pyrex is initialized:
+#   ${pyrex:pyrexroot}      The absolute path to Pyrex (e.g. $PYREX_ROOT)
+#
+
+# Pyrex build information. Any changes to this section will require
+# reinitializing the build environment to take effect.
+[config]
+# The version of Pyrex this config is written against. This option is required
+# to be specified in the user config file
+confversion = 2
+
+# A list of globs for commands that should be wrapped by Pyrex. Overrides the
+# command set specified by the container itself when it was captured. Any path
+# starting with a "!" will be excluded from being wrapped by Pyrex and will
+# run directly in the host environment
+#commands =
+#    ${env:PYREX_OEROOT}/bitbake/bin/*
+#    ${env:PYREX_OEROOT}/scripts/*
+#    !${env:PYREX_OEROOT}/scripts/runqemu*
+
+# The Container engine executable (e.g. docker, podman) to use. If the path
+# does not start with a "/", the $PATH environment variable will be searched
+# (i.e. execvp rules)
+#engine = docker
+
+# The type of image to build
+#imagetype = oe
+
+# As a convenience, the name of a Pyrex provided image
+# can be specified here
+#image = build-nilrt
+
+# As a convenience, the tag of the Pyrex provided image. Defaults to the
+# Pyrex version.
+#pyrextag = latest
+
+# The name of the tag given to the image. If you want to keep around different
+# Pyrex images simultaneously, each should have a unique tag
+#tag = garminpyrex/${config:image}:${config:pyrextag}
+tag = build-nilrt:sumo
+
+# If set to 1, the image is built up locally every time the environment is
+# sourced. If set to 0, building the image will be skipped, which means that
+# the container engine may attempt to download a prebuilt image from a
+# repository
+buildlocal = 0
+
+# The name of the registry where to find the image whose complete name is stored
+# in tag variable. This variable is only used when buildlocal is set to 0.
+#registry = docker.io
+
+# A list of environment variables that should be imported as Pyrex
+# configuration variables in the "env" section, e.g. ${env:HOME}. Note that
+# environment variables accessed in this way must be set or an error will
+# occur. Default values can be assigned by making an "env" section in this file
+# and populating it with the default values. Also note that Pyrex will attempt
+# to perform variable expansion on the environment variable values, so care
+# should be taken
+#envimport =
+#    HOME
+#    PYREX_BIND
+
+[imagebuild]
+# The command used to build container images
+buildcommand = bash ${pyrex:pyrexroot}/../../docker/create-build-nilrt.sh sumo
+
+# Build quietly?
+#quiet = true
+quiet = false
+
+# Environment variables to set when building the image
+#env =
+#   DOCKER_BUILDKIT=1
+
+# Capture options. Changes in the section only affect when a Pyrex container is
+# initialized
+[capture]
+envvars =
+	BB_ENV_EXTRAWHITE
+#	TERM
+#   BDIR
+#   BITBAKEDIR
+#   OEROOT
+
+# Runtime options. Changes in this section take effect the next time a Pyrex
+# command is run
+[run]
+# A list of directories that should be bound when running in the container
+#bind =
+#   ${env:PYREX_BIND}
+
+# A list of environment variables that should be propagated to the container
+# if set in the parent environment
+envvars =
+	SSTATE_MIRRORS
+#	GIT_REPODIR
+#   http_proxy
+#   https_proxy
+#   SSH_AUTH_SOCK
+
+# Environment variables that contain the path to a socket that should be
+# proxied into the container (if set in the host environment)
+#envsockproxy =
+#   SSH_AUTH_SOCK
+
+# Extra arguments to pass when running the image. For example:
+#   --mount type=bind,src=${env:HOME}/.ssh,dst=${env:HOME}/.ssh,readonly
+#   --device /dev/kvm
+args =
+	--device /dev/kvm
+
+# Prefix for all Pyrex commands. Useful for debugging. For example:
+#   strace -ff -ttt -o strace.log --
+#commandprefix =
+
+# Assign default values for environment variables in this section
+[env]
+#PYREX_BIND=

--- a/scripts/azdo/conf/pyrex.ini
+++ b/scripts/azdo/conf/pyrex.ini
@@ -1,0 +1,120 @@
+# Pyrex User Configuration
+#
+# The following variables are made available as variable expansions when
+# Pyrex is initialized:
+#   ${pyrex:pyrexroot}      The absolute path to Pyrex (e.g. $PYREX_ROOT)
+#
+
+# Pyrex build information. Any changes to this section will require
+# reinitializing the build environment to take effect.
+[config]
+# The version of Pyrex this config is written against. This option is required
+# to be specified in the user config file
+confversion = 2
+
+# A list of globs for commands that should be wrapped by Pyrex. Overrides the
+# command set specified by the container itself when it was captured. Any path
+# starting with a "!" will be excluded from being wrapped by Pyrex and will
+# run directly in the host environment
+#commands =
+#    ${env:PYREX_OEROOT}/bitbake/bin/*
+#    ${env:PYREX_OEROOT}/scripts/*
+#    !${env:PYREX_OEROOT}/scripts/runqemu*
+
+# The Container engine executable (e.g. docker, podman) to use. If the path
+# does not start with a "/", the $PATH environment variable will be searched
+# (i.e. execvp rules)
+#engine = docker
+
+# The type of image to build
+#imagetype = oe
+
+# As a convenience, the name of a Pyrex provided image
+# can be specified here
+#image = build-nilrt
+
+# As a convenience, the tag of the Pyrex provided image. Defaults to the
+# Pyrex version.
+#pyrextag = latest
+
+# The name of the tag given to the image. If you want to keep around different
+# Pyrex images simultaneously, each should have a unique tag
+tag = ${env:BUILD_NILRT_IMAGE_NAME}:${env:BUILD_NILRT_IMAGE_TAG}
+
+# If set to 1, the image is built up locally every time the environment is
+# sourced. If set to 0, building the image will be skipped, which means that
+# the container engine may attempt to download a prebuilt image from a
+# repository
+buildlocal = 0
+
+# The name of the registry where to find the image whose complete name is stored
+# in tag variable. This variable is only used when buildlocal is set to 0.
+#registry = docker.io
+
+# A list of environment variables that should be imported as Pyrex
+# configuration variables in the "env" section, e.g. ${env:HOME}. Note that
+# environment variables accessed in this way must be set or an error will
+# occur. Default values can be assigned by making an "env" section in this file
+# and populating it with the default values. Also note that Pyrex will attempt
+# to perform variable expansion on the environment variable values, so care
+# should be taken
+envimport =
+	HOME
+	PYREX_BIND
+	BUILD_NILRT_IMAGE_NAME
+	BUILD_NILRT_IMAGE_TAG
+
+[imagebuild]
+# The command used to build container images
+buildcommand = bash ${pyrex:pyrexroot}/../../docker/create-build-nilrt.sh sumo
+
+# Build quietly?
+#quiet = true
+quiet = false
+
+# Environment variables to set when building the image
+#env =
+#   DOCKER_BUILDKIT=1
+
+# Capture options. Changes in the section only affect when a Pyrex container is
+# initialized
+[capture]
+envvars =
+	BB_ENV_EXTRAWHITE
+#	TERM
+#   BDIR
+#   BITBAKEDIR
+#   OEROOT
+
+# Runtime options. Changes in this section take effect the next time a Pyrex
+# command is run
+[run]
+# A list of directories that should be bound when running in the container
+bind =
+   ${env:PYREX_BIND}
+
+# A list of environment variables that should be propagated to the container
+# if set in the parent environment
+envvars =
+	SSTATE_MIRRORS
+#	GIT_REPODIR
+#   http_proxy
+#   https_proxy
+#   SSH_AUTH_SOCK
+
+# Environment variables that contain the path to a socket that should be
+# proxied into the container (if set in the host environment)
+#envsockproxy =
+#   SSH_AUTH_SOCK
+
+# Extra arguments to pass when running the image. For example:
+#   --mount type=bind,src=${env:HOME}/.ssh,dst=${env:HOME}/.ssh,readonly
+#   --device /dev/kvm
+
+# Prefix for all Pyrex commands. Useful for debugging. For example:
+#   strace -ff -ttt -o strace.log --
+#commandprefix =
+
+# Assign default values for environment variables in this section
+[env]
+#PYREX_BIND=

--- a/scripts/pipelines/build.common.sh
+++ b/scripts/pipelines/build.common.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+SCRIPT_ROOT=$(realpath $(dirname $BASH_SOURCE))
+
+. "${SCRIPT_ROOT}/../../ni-oe-init-build-env" $@
+
+bitbake --version
+#printenv | grep -i ^PYREX
+
+export PS1="[bb] $PS1"
+
+echo "INFO: Entered bitbake environment."

--- a/scripts/pipelines/build.extra-feeds.sh
+++ b/scripts/pipelines/build.extra-feeds.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_ROOT=$(realpath $(dirname $BASH_SOURCE))
+DELETE_DUPLICATE_IPKS="bash ${SCRIPT_ROOT}/delete-duplicate-ipks.sh"
+
+## ARGUMENT PARSING
+usage() {
+	cat <<EOF
+$(basename $BASH_SOURCE) [--help] [--desirable-only] [--no-index] \\
+    [CORE_FEED_PATH]
+
+Builds the NILRT extra/ package feed. If CORE_FEED_PATH is asserted, also
+remove any packages from the extras feed which is already in core/.
+
+# Options
+-d, --desirable-only
+  If asserted, only build the 'desirable' packagegroup and do not attempt to
+  build the entire 'extra' feed (which takes a long time.)
+-n, --no-index
+  If asserted, skip creating the package-index at the end of feed generation.
+
+# Positional Arguments
+CORE_FEED_PATH
+  Filepath to the root of the NILRT core/ IPK feed.
+EOF
+	exit ${1:-2}
+}
+
+desirable_only=false
+skip_package_index=false
+core_feed_path=""
+
+positionals=()
+while [ $# -ge 1 ]; do case "$1" in
+	-h|--help)
+		usage 0
+		;;
+	-d|--desirable-only)
+		desirable_only=true
+		shift
+		;;
+	-n|--no-index)
+		skip_package_index=true
+		shift
+		;;
+	-*|--*)
+		echo "ERROR: unknown option: $1" >&2
+		usage >&2
+		;;
+	*)
+		positionals+=($1)
+		shift
+		;;
+esac; done
+# Assign positionals to named variables, because scripts that we source later
+# in this file (eg. ni-oe-init-build-env) can overwrite the "positionals"
+# variable as a part of their native arg-parsing.
+# core_feed_path must be absolute here, because entering the pyrex build env
+# will switch the CWD.
+if [ ${#positionals[@]} -gt 0 ]; then
+	core_feed_path="$(realpath ${positionals[0]})"
+fi
+
+
+## MAIN
+. "${SCRIPT_ROOT}/build.common.sh" >/dev/null
+# Now in the OE+Pyrex build/ workspace...
+
+echo "INFO: Building the extra package feed."
+bitbake packagegroup-ni-desirable
+
+if [ ! "$desirable_only" = true ]; then
+	bitbake --continue packagefeed-ni-extra || true
+else
+	echo "INFO: 'desirable-only' requested; skipping full extra feed build."
+fi
+
+# If the user provided a core/ feed path, dedupe against it.
+if [ -n "${core_feed_path}" ]; then
+	[ -d "$core_feed_path" ] || (echo "ERROR: core feed path $core_feed_path is not a directory." >&2; exit 1)
+
+	echo "Pruning all packages from the extras feed which are already in core."
+	$DELETE_DUPLICATE_IPKS \
+		"${core_feed_path}" \
+		"./tmp-glibc/deploy/ipk"
+fi
+
+# Package index generation must happen after we have deduped IPKs.
+if [ "$skip_package_index" != true ]; then
+	echo "INFO: Generating extra/ feed indexes."
+	bitbake package-index
+else
+	echo "INFO: Skipping package index generation by user request."
+fi

--- a/scripts/pipelines/delete-duplicate-ipks.sh
+++ b/scripts/pipelines/delete-duplicate-ipks.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# This script compares the IPK contents of two feed trees and removes any IPKs
+# in the subordinate feed which are already present in the superordinate feed.
+set -euo pipefail
+
+
+function usage() {
+	local returncode=${1:-2}
+	local helptext=$(cat <<EOF
+$(basename $0) [-h|--help] [-n|--dry-run] [-v|--verbose] superordinate subordinate
+
+Compares the IPK contents of two feed trees, optionally removing duplicate IPKs
+from the subordinate feed.
+
+Opts:
+-h|--help     Print this help text and exit (stdout).
+-n|--dry-run  Do everything except actually deleting the common IPKs.
+-v|--verbose  Enable verbose reporting of which files are going to be deleted
+              (stdout).
+
+Positionals:
+(super|sub)ordinate   Path to the feed tree root for each feed in comparison.
+EOF
+)
+
+	if [ "$returncode" == 2 ]; then
+		echo "${helptext}" >&1
+	else
+		echo "${helptext}" >&2
+	fi
+	exit $returncode
+}
+
+[ $# -lt 1 ] && usage
+
+
+## OPTIONS PARSING ##
+opt_dry_run=false
+opt_verbose=false
+
+opt_pos=()
+while [ $# -gt 0 ]; do
+	case "$1" in
+		-h|--help)
+			usage 0
+			shift
+			;;
+		-n|--dry-run)
+			opt_dry_run=true
+			shift
+			;;
+		-v|--verbose)
+			opt_verbose=true
+			shift
+			;;
+		-*)
+			usage 2
+			;;
+		*)
+			opt_pos+=("$1")
+			shift
+			;;
+	esac
+done
+if [ "${#opt_pos[@]}" -ne 2 ]; then
+	usage 2
+fi
+feed_super=${opt_pos[0]}
+feed_sub=${opt_pos[1]}
+
+echo "Comparing feeds:"
+echo "Superordinate: ${feed_super}"
+echo "Subordinate:   ${feed_sub}"
+$opt_dry_run && echo "!! DRY RUN !! No files will be removed."
+
+
+## SANITY CHECKS ##
+# Since this script involves deleting many files, do a couple sanity checks.
+# CHECK 1 - Both feed paths are actually directories
+test -d "${feed_super}" || (echo "ERROR: ${feed_super} is not a real directory path." && exit 1)
+test -d "${feed_sub}" || (echo "ERROR: ${feed_sub} is not a real directory path." && exit 1)
+# CHECK 2 - The feeds are not the same. (If they are, then we would delete every IPK.)
+if [ "$(realpath ${feed_super})" = "$(realpath ${feed_sub})" ]; then
+	echo "ERROR: Supplied feed paths are actually the same directory." && exit 1
+fi
+
+
+# Collect all the IPK paths from each feed
+find_exec="-printf %P\n"
+
+ipk_super=$(find ${feed_super} -name '*.ipk' ${find_exec} | sort)
+ipk_sub=$(find ${feed_sub} -name '*.ipk' ${find_exec} | sort)
+
+
+# find entries common to both feeds
+common=$(comm -12 <(cat <<<$ipk_super) <(cat <<<$ipk_sub))
+
+# process each entry
+count=0
+for entry in $common; do
+	sub_entry_path="${feed_sub}/${entry}"
+	if $opt_dry_run; then
+		$opt_verbose && echo "${sub_entry_path}"
+	else
+		rm $(if $opt_verbose; then echo --verbose; fi) ${sub_entry_path}
+	fi
+	count=$(($count + 1))
+done
+
+echo "Processed $count common entries."


### PR DESCRIPTION
This PR...
1. adds the `pyrex` tool, in the same way that we have added it to the hardknott mainline.
2. adds a `docker/` directory containing a similar docker configuration as in hardknott, but using the `ubuntu-18.04-oe` pyrex container as its base (instead of `ubuntu-20.04-oe` in hardknott).
3. backports the relevant supporting `scripts/` files from hardknott - without modification,
4. merges the sumo and hardknott `ni-oe-init-build-env` scripts.

# Testing
* Used the new init script to build bitbake on my dev machine.