### PR TITLE
[dist-feed] Include 22.0 arm dist-nilrt-grub

### DIFF
--- a/scripts/jenkins/dist-feed/dist-feed-manifest.yml
+++ b/scripts/jenkins/dist-feed/dist-feed-manifest.yml
@@ -120,6 +120,9 @@ packages:
   dist-nilrt-grub_21.8_x64:
     export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/21.8') | latest_export }}"
     ipk_path: 'targets/linuxU/x64/gcc-4.7-oe/release/onert_system_image_ipk/dist-nilrt-grub_*.ipk'
+  dist-nilrt-grub_22.0_arm:
+    export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/22.0') | latest_export }}"
+    ipk_path: 'targets/linuxU/armv7-a/gcc-4.7-oe/release/onert_system_image_ipk/dist-nilrt-grub_*.ipk'
   dist-nilrt-grub_22.0_x64:
     export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/22.0') | latest_export }}"
     ipk_path: 'targets/linuxU/x64/gcc-4.7-oe/release/onert_system_image_ipk/dist-nilrt-grub_*.ipk'


### PR DESCRIPTION
[dist-feed] Include 22.0 combo, pxi, and arm dist-nilrt-grubs.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

AzDO work item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1956633/

## Testing:
Built locally and confirmed both the ipks were in the `scripts/jenkins/dist-feed/build/dist` folder:
- dist-nilrt-grub_22.0.0.98-0+d98_core2-64.ipk
- dist-nilrt-grub_22.0.0.98-0+d98_cortexa9-vfpv3.ipk 