### PR TITLE
pyrex: enable containers-by-digest

### DIFF
--- a/ni-oe-init-build-env
+++ b/ni-oe-init-build-env
@@ -133,6 +133,9 @@ export PYREX_CONFIG_BIND="${NILRT_ROOT}"
 export PYREX_OEINIT="${NILRT_ROOT}/sources/openembedded-core/oe-init-build-env"
 export PYREX_ROOT="${NILRT_ROOT}/sources/pyrex"
 
+export PYREX_BUILD_NILRT_IMAGE="${PYREX_BUILD_NILRT_IMAGE:-build-nilrt:latest}"
+echo "INFO: Using pyrex image: ${PYREX_BUILD_NILRT_IMAGE}"
+
 
 unset SCRIPT_ROOT
 

--- a/pyrex.ini
+++ b/pyrex.ini
@@ -24,23 +24,14 @@ confversion = 2
 # The Container engine executable (e.g. docker, podman) to use. If the path
 # does not start with a "/", the $PATH environment variable will be searched
 # (i.e. execvp rules)
-#engine = docker
+engine = docker
 
 # The type of image to build
 #imagetype = oe
 
-# As a convenience, the name of a Pyrex provided image
-# can be specified here
-#image = build-nilrt
-
-# As a convenience, the tag of the Pyrex provided image. Defaults to the
-# Pyrex version.
-#pyrextag = latest
-
 # The name of the tag given to the image. If you want to keep around different
 # Pyrex images simultaneously, each should have a unique tag
-#tag = garminpyrex/${config:image}:${config:pyrextag}
-tag = build-nilrt:latest
+tag = ${env:PYREX_BUILD_NILRT_IMAGE}
 
 # If set to 1, the image is built up locally every time the environment is
 # sourced. If set to 0, building the image will be skipped, which means that
@@ -59,9 +50,10 @@ buildlocal = 0
 # and populating it with the default values. Also note that Pyrex will attempt
 # to perform variable expansion on the environment variable values, so care
 # should be taken
-#envimport =
-#    HOME
-#    PYREX_BIND
+envimport =
+	HOME
+	PYREX_BIND
+	PYREX_BUILD_NILRT_IMAGE
 
 [imagebuild]
 # The command used to build container images
@@ -89,8 +81,8 @@ envvars =
 # command is run
 [run]
 # A list of directories that should be bound when running in the container
-#bind =
-#   ${env:PYREX_BIND}
+bind =
+   ${env:PYREX_BIND}
 
 # A list of environment variables that should be propagated to the container
 # if set in the parent environment

--- a/scripts/azdo/conf/pyrex.ini
+++ b/scripts/azdo/conf/pyrex.ini
@@ -24,22 +24,14 @@ confversion = 2
 # The Container engine executable (e.g. docker, podman) to use. If the path
 # does not start with a "/", the $PATH environment variable will be searched
 # (i.e. execvp rules)
-#engine = docker
+engine = docker
 
 # The type of image to build
 #imagetype = oe
 
-# As a convenience, the name of a Pyrex provided image
-# can be specified here
-#image = build-nilrt
-
-# As a convenience, the tag of the Pyrex provided image. Defaults to the
-# Pyrex version.
-#pyrextag = latest
-
 # The name of the tag given to the image. If you want to keep around different
 # Pyrex images simultaneously, each should have a unique tag
-tag = ${env:BUILD_NILRT_IMAGE_NAME}:${env:BUILD_NILRT_IMAGE_TAG}
+tag = ${env:PYREX_BUILD_NILRT_IMAGE}
 
 # If set to 1, the image is built up locally every time the environment is
 # sourced. If set to 0, building the image will be skipped, which means that
@@ -61,8 +53,7 @@ buildlocal = 0
 envimport =
 	HOME
 	PYREX_BIND
-	BUILD_NILRT_IMAGE_NAME
-	BUILD_NILRT_IMAGE_TAG
+	PYREX_BUILD_NILRT_IMAGE
 
 [imagebuild]
 # The command used to build container images


### PR DESCRIPTION
The current pyrex implementation assumes that users wish to start
containers using the `$name:$tag` format. Users may not use the
`$name@$digest` format, which is preferable in environments where
build-reproducibility is required.

Change the pyrex.ini to eschew this assumption and update the init
script to allow the user to pull containers by digest.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

This PR is needed to use static containers in our AZDO pipeline.

# Testing
* Exported a `PYREX_BUILD_NILRT_IMAGE` variable with the full digest name of the latest `hardknott`-tagged `build-nilrt` container on `rnd-builds.repos.natinst.com`, and ran the init script. It correctly used the container-by-digest.
* Unexported the image variable and ran the initscript. Pyrex started using the `build-nilrt:latest` tag from my dev-machine.