### PR TITLE
[sumo] pyrex: enable containers-by-digest

### DIFF
--- a/ni-oe-init-build-env
+++ b/ni-oe-init-build-env
@@ -133,6 +133,9 @@ export PYREX_CONFIG_BIND="${NILRT_ROOT}"
 export PYREX_OEINIT="${NILRT_ROOT}/sources/openembedded-core/oe-init-build-env"
 export PYREX_ROOT="${NILRT_ROOT}/sources/pyrex"
 
+export PYREX_BUILD_NILRT_IMAGE="${PYREX_BUILD_NILRT_IMAGE:-build-nilrt:latest}"
+echo "INFO: Using pyrex image: ${PYREX_BUILD_NILRT_IMAGE}"
+
 
 unset SCRIPT_ROOT
 

--- a/ni-oe-init-build-env
+++ b/ni-oe-init-build-env
@@ -133,7 +133,8 @@ export PYREX_CONFIG_BIND="${NILRT_ROOT}"
 export PYREX_OEINIT="${NILRT_ROOT}/sources/openembedded-core/oe-init-build-env"
 export PYREX_ROOT="${NILRT_ROOT}/sources/pyrex"
 
-export PYREX_BUILD_NILRT_IMAGE="${PYREX_BUILD_NILRT_IMAGE:-build-nilrt:latest}"
+nilrt_codename=$(grep -e '^LAYERSERIES_COMPAT_meta-nilrt' "${TEMPLATECONF}/layer.conf" | cut -d'"' -f2)
+export PYREX_BUILD_NILRT_IMAGE="${PYREX_BUILD_NILRT_IMAGE:-build-nilrt:${nilrt_codename}}"
 echo "INFO: Using pyrex image: ${PYREX_BUILD_NILRT_IMAGE}"
 
 

--- a/pyrex.ini
+++ b/pyrex.ini
@@ -24,23 +24,14 @@ confversion = 2
 # The Container engine executable (e.g. docker, podman) to use. If the path
 # does not start with a "/", the $PATH environment variable will be searched
 # (i.e. execvp rules)
-#engine = docker
+engine = docker
 
 # The type of image to build
 #imagetype = oe
 
-# As a convenience, the name of a Pyrex provided image
-# can be specified here
-#image = build-nilrt
-
-# As a convenience, the tag of the Pyrex provided image. Defaults to the
-# Pyrex version.
-#pyrextag = latest
-
 # The name of the tag given to the image. If you want to keep around different
 # Pyrex images simultaneously, each should have a unique tag
-#tag = garminpyrex/${config:image}:${config:pyrextag}
-tag = build-nilrt:sumo
+tag = ${env:PYREX_BUILD_NILRT_IMAGE}
 
 # If set to 1, the image is built up locally every time the environment is
 # sourced. If set to 0, building the image will be skipped, which means that
@@ -59,9 +50,10 @@ buildlocal = 0
 # and populating it with the default values. Also note that Pyrex will attempt
 # to perform variable expansion on the environment variable values, so care
 # should be taken
-#envimport =
-#    HOME
-#    PYREX_BIND
+envimport =
+	HOME
+	PYREX_BIND
+	PYREX_BUILD_NILRT_IMAGE
 
 [imagebuild]
 # The command used to build container images
@@ -89,8 +81,8 @@ envvars =
 # command is run
 [run]
 # A list of directories that should be bound when running in the container
-#bind =
-#   ${env:PYREX_BIND}
+bind =
+   ${env:PYREX_BIND}
 
 # A list of environment variables that should be propagated to the container
 # if set in the parent environment

--- a/scripts/azdo/conf/pyrex.ini
+++ b/scripts/azdo/conf/pyrex.ini
@@ -24,22 +24,14 @@ confversion = 2
 # The Container engine executable (e.g. docker, podman) to use. If the path
 # does not start with a "/", the $PATH environment variable will be searched
 # (i.e. execvp rules)
-#engine = docker
+engine = docker
 
 # The type of image to build
 #imagetype = oe
 
-# As a convenience, the name of a Pyrex provided image
-# can be specified here
-#image = build-nilrt
-
-# As a convenience, the tag of the Pyrex provided image. Defaults to the
-# Pyrex version.
-#pyrextag = latest
-
 # The name of the tag given to the image. If you want to keep around different
 # Pyrex images simultaneously, each should have a unique tag
-tag = ${env:BUILD_NILRT_IMAGE_NAME}:${env:BUILD_NILRT_IMAGE_TAG}
+tag = ${env:PYREX_BUILD_NILRT_IMAGE}
 
 # If set to 1, the image is built up locally every time the environment is
 # sourced. If set to 0, building the image will be skipped, which means that
@@ -61,8 +53,7 @@ buildlocal = 0
 envimport =
 	HOME
 	PYREX_BIND
-	BUILD_NILRT_IMAGE_NAME
-	BUILD_NILRT_IMAGE_TAG
+	PYREX_BUILD_NILRT_IMAGE
 
 [imagebuild]
 # The command used to build container images


### PR DESCRIPTION
This PR is the same as #144 , but adds a line to the initscript which causes it to default to using the release codename as the default image tag, if the user doesn't specify one.

This PR is needed for static-container-building to work in the AZDO pipelines.

# Testing
* Ran the initscript with and without `PYREX_BUILD_NILRT_IMAGE` defined in the shell environment; verified that the initscript started the correct container in each case.