### PR TITLE
Update packagegroup to build extra feed correctly

### DIFF
--- a/scripts/pipelines/build.extra-feeds.sh
+++ b/scripts/pipelines/build.extra-feeds.sh
@@ -71,7 +71,7 @@ echo "INFO: Building the extra package feed."
 bitbake packagegroup-ni-desirable
 
 if [ ! "$desirable_only" = true ]; then
-	bitbake --continue packagefeed-ni-extra || true
+	bitbake --continue packagegroup-ni-extra || true
 else
 	echo "INFO: 'desirable-only' requested; skipping full extra feed build."
 fi


### PR DESCRIPTION
The sumo extras feed was not being built completely because
packagefeed-ni-extra is a hardknott-specific packagegroup name. Fix
the feed by updating to sumo packagegroup `packagegroup-ni-extra`.

Haven't tested the change, I expect it to just work.