### PR TITLE
dist-feed: add 22.8 dist-nilrt-grubs to dist feed

### DIFF
--- a/scripts/jenkins/dist-feed/dist-feed-manifest.yml
+++ b/scripts/jenkins/dist-feed/dist-feed-manifest.yml
@@ -126,6 +126,12 @@ packages:
   dist-nilrt-grub_22.5_x64:
     export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/22.5') | latest_export }}"
     ipk_path: 'targets/linuxU/x64/gcc-4.7-oe/release/onert_system_image_ipk/dist-nilrt-grub_*.ipk'
+  dist-nilrt-grub_22.8_arm:
+    export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/22.8') | latest_export }}"
+    ipk_path: 'targets/linuxU/armv7-a/gcc-4.7-oe/release/onert_system_image_ipk/dist-nilrt-grub_*.ipk'
+  dist-nilrt-grub_22.8_x64:
+    export: "{{ (MNT_NIRVANA_PERFORCEEXPORTS + '/build/exports/ni/nilr/nilrt_onert_system_image/official/export/22.8') | latest_export }}"
+    ipk_path: 'targets/linuxU/x64/gcc-4.7-oe/release/onert_system_image_ipk/dist-nilrt-grub_*.ipk'
   dist-nilrt-systemlink-grub_19.6_arm-crio:
     export: "{{ (((MNT_NIRVANA_PERFORCEEXPORTS + '/MAX/sysmgmt/installers/current_gen/skyline_rt_client_runtime/export/19.6') | latest_export) + '/.archives/linux.zip') | unzip }}"
     ipk_path: 'targets/linuxU/armv7-a/gcc-4.9-oe/release/dist_nilrt_systemlink_grub_ipk/dist-nilrt-systemlink-grub_*.ipk'


### PR DESCRIPTION
### Testing
Ran `make` and verified dist feed contains `dist-nilrt-grub` 22.8 ipks.