### PR TITLE
README.kernel.md: Fix formatting of commands

### DIFF
--- a/docs/README.kernel.md
+++ b/docs/README.kernel.md
@@ -22,14 +22,18 @@ A Linux machine to build the kernel with:
 
 1. Clone the source from github.com/ni/linux.
 
+    ```
     git clone https://github.com/ni/linux.git
     cd linux
+    ```
 
 2. Checkout the branch that corresponds to the release you are using.
 
+    ```
     git checkout nilrt/<release>/4.14
+    ```
 
-Note that only kernel versions 4.14 and below support ARM targets at
+   Note that only kernel versions 4.14 and below support ARM targets at
 this time.
 
 
@@ -55,67 +59,89 @@ For x64-based targets:
 
 1. Set the kernel configuration to match NI’s settings.
 
+    ```
     export ARCH=x86_64
     export CROSS_COMPILE=/path/to/toolchain/usr/bin/x86_64-nilrt-linux/x86_64-nilrt-linux-
     make nati_x86_64_defconfig
+    ```
 
 2. Compile the kernel.
 
+    ```
     make -j<number_of_parallel_jobs> bzImage modules
     make modules_install INSTALL_MOD_PATH=<temporary_host_side_modules_location>
+    ```
 
 3. (optional) Backup /boot/runmode/bzImage on the target.
 
+    ```
     cd /boot/runmode/
     mv bzImage bzImage-`uname -r`
+    ```
 
 4. Copy the new kernel to the target.
 
+    ```
     scp arch/x86/boot/bzImage admin@<target>:/boot/runmode/
     cd <temporary_host_side_modules_location>
     tar cz lib | ssh admin@<target> tar xz -C /
+    ```
 
-Note that the build and source symlinks in the modules directory do
+   Note that the build and source symlinks in the modules directory do
 not need to be copied over to the target. The `tar` command above will
 not follow the symlinks.
 
 5. Reboot the target.
 
+    ```
     reboot
+    ```
 
 6. (optional) Check version of the updated kernel on the target.
 
+    ```
     uname -a
+    ```
 
 For ARM-based targets:
 
 1. Set the kernel configuration to match NI’s settings.
 
+    ```
     export ARCH=arm
     export CROSS_COMPILE=/path/to/toolchain/usr/bin/arm-nilrt-linux-gnueabi/arm-nilrt-linux-gnueabi-
     make nati_zynq_defconfig
+    ```
 
 2. Compile the kernel.
 
+    ```
     make ni-pkg
+    ```
 
 3. Copy the new kernel to the target.
 
+    ```
     scp ni-install/arm/boot/ni_zynq_custom_runmodekernel.itb admin@<target>:/boot/linux_runmode.itb
     cd ni-install/arm/lib/modules/
     tar cz lib | ssh admin@<target> tar xz -C /
+    ```
 
-Note that the build and source symlinks in the modules directory do
+   Note that the build and source symlinks in the modules directory do
 not need to be copied over to the target. The `tar` command above will
 not follow the symlinks.
 
 5. Reboot the target.
 
+    ```
     reboot
+    ```
 
 6. (optional) Check version of the updated kernel on the target.
 
+    ```
     uname -a
+    ```
 
 ### Rebuilding NI out-of-tree Drivers with DKMS
 
@@ -130,46 +156,60 @@ the host build machine.
 
 1. Start the sshd daemon on the host.
 
+    ```
     sudo systemctl start sshd
+    ```
 
 2. Install sshfs on the target.
 
+    ```
     opkg update
     opkg install sshfs-fuse
     modprobe fuse
+    ```
 
 3. Mount the kernel source on the target.
 
+    ```
     mkdir /usr/src/linux
     sshfs <user>@<host>:<path_to_kernel_source> /usr/src/linux
+    ```
 
 4. Fix dangling build and source symlinks.
 
+    ```
     cd /lib/modules/`uname -r`/
     rm build source
     ln -s /usr/src/linux source
     ln -s source build
+    ```
 
 5. Prepare the tools needed for dkms.
 
+    ```
     cd /lib/modules/`uname -r`/build
     make prepare
     make modules_prepare
+    ```
 
-Note that you may need to install the bc package on ARM targets.
+   Note that you may need to install the bc package on ARM targets.
 
 6. Re-version the NI modules.
 
+    ```
     dkms autoinstall
+    ```
 
-If you get strange gcc errors during this step, ensure that the gcc
+   If you get strange gcc errors during this step, ensure that the gcc
 version used to build the kernel on the host machine is compatible
 with the gcc version on the target. Check the output logs under:
 /var/lib/dkms/<ni_module>/<version>/build/make.log.
 
 7. (optional) Check dkms status.
 
+    ```
     dkms status
+    ```
 
 8. Reboot the target.
 
@@ -182,3 +222,4 @@ the controller to boot into safe mode and format from MAX.
 *** NOTE ***
 Changes to the kernel running on the target will be lost in certain operations
 from MAX, including formatting the target and uninstalling all components.
+


### PR DESCRIPTION
The formatting of the commands in the markdown was off.

