### PR TITLE
Add upstream hashserver for internal builds.

### DIFF
--- a/scripts/azdo/conf/ni-org.conf
+++ b/scripts/azdo/conf/ni-org.conf
@@ -17,3 +17,11 @@ PRSERV_HOST = "versionator.amer.corp.natinst.com:8585"
 # Internal feed configuration.
 #
 NILRT_FEEDS_URI ?= "http://nickdanger.amer.corp.natinst.com/feeds"
+
+#
+# Internal hashserver configuration.
+#
+#
+BB_SIGNATURE_HANDLER = "OEEquivHash"
+BB_HASHSERVE = "auto"
+BB_HASHSERVE_UPSTREAM = "rtosams.amer.corp.natinst.com:8687"


### PR DESCRIPTION
Enable the local hashserver with an upstream so
we can test performance benefits on our internal
builds.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

# Testing:
Built locally. Note that full benefits from this will initially only be seen on PR builds which copy the sstate-cache from argo. Eventually, we would like to have an sstate-cache mirror that can be used for this on developer builds. 