### PR TITLE
[hardknott] Add workflow to sync issues to AzDO

### DIFF
--- a/.github/workflows/sync_issues_to_azdo.yml
+++ b/.github/workflows/sync_issues_to_azdo.yml
@@ -1,0 +1,24 @@
+name: Sync issue to Azure DevOps work item
+
+on:
+  issues:
+    types:
+      [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned]
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: danhellem/github-actions-issue-to-work-item@master
+        env:
+          ado_token: "${{ secrets.AZDO_WORK_ITEM_TOKEN }}"
+          github_token: "${{ secrets.GH_REPO_TOKEN }}"
+          ado_organization: "ni"
+          ado_project: "DevCentral"
+          ado_area_path: "DevCentral\\Product RnD\\PlatformSW\\Platform HW and Drivers\\Drivers\\RTOS"
+          ado_wit: "Bug"
+          ado_new_state: "New"
+          ado_active_state: "Active"
+          ado_close_state: "Closed"
+          ado_bypassrules: true
+          log_level: 100


### PR DESCRIPTION
Currently, internal work items to track GitHub Issues
are created manually. This adds a workflow that uses
Actions to create an AzDO bug to track issues on
our internal work board.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

**Note:** this approach is taken from the grpc-device repo: https://github.com/ni/grpc-device/blob/main/.github/workflows/sync_github_issues_to_azdo.yml

AzDO Work Item: https://dev.azure.com/ni/DevCentral/_workitems/edit/1012205

## Testing: 
This will not be testable until it's submitted. At that point, I can create an issue and see that a bug is created. 