### PR TITLE
Create scripts to estimate sizes of nilrt images

### DIFF
--- a/scripts/dev/estimate-usage/README.md
+++ b/scripts/dev/estimate-usage/README.md
@@ -1,0 +1,103 @@
+# `estimate-usage` scripts
+These scripts exist to allow developers to determine approximately how much disk
+space will be used by a system image when it is deployed.
+
+Note that the sizes returned are **approximate**. The estimation scripts don't
+necessarily use the same software versions or command-line invocations that
+happen on real targets.
+
+## The platform-specific scripts
+The `estimate-usage.<platform>.<image-type>.sh` scripts in this directory are
+designed to consume system images and determine the disk space usage if their
+contents are unpacked into the default filesystem of the platform.
+
+### Running
+These scripts consider every argument given to be an image to provide an
+estimate for. If no arguments are given, they read from standard input. There is
+no argument parsing: there are no command-line options, and an argument of `-`
+does not indicate standard input.
+
+### Privileges
+These scripts assume that they will be executed with sufficient privileges to
+perform mounts, write to device files, and (un)load kernel modules. For this
+reason, they are intended to be run within a virtual machine. They will attempt
+to clean up after themselves, but **may have unintended consequences**: for
+instance, the runmode estimation script for ARMv7-A assumes that it creates the
+ubi flash device `/dev/ubi0` and writes to it, so if that device already exists
+you may suffer data loss.
+
+### Software requirements
+Running the scripts for ARMv7-A requires MTD and U-Boot tools for runmode and
+safemode, respectively. On Debian, the packages can be installed with:
+
+    apt-get install mtd-utils u-boot-tools
+
+### Output format
+The output of these scripts is a five-column TSV (tab-separated value) table on
+standard output. The columns have the following meanings:
+
+ 1. The name of the image examined
+ 2. The CPU architecture (`x86_64` or `ARMv7-A`, assumed by the script)
+ 3. The type of image (`runmode` or `safemode`, assumed by the script)
+ 4. The type of measurement (`disk footprint` or `kernel + ramdisk`)
+ 5. The human-readable size in bytes, using binary-sized prefixes K, M, G, and
+    so on.
+
+## The top-level script
+The `estimate-usage.sh` script here fetches the latest exports of the system
+images, starts a virtual machine, and runs the platform-specific scripts within
+the virtual machine to determine the space usage of those images.
+
+### Running
+This script ignores all arguments.
+
+### Source of images
+When the script searches for the latest exports, it looks in the network shares
+on the NI corporate network. There are environment variables to control where
+the searching starts:
+
+ - `EXPORTS_DIR`: the location of `\\nirvana\perforceExports\build\exports`,
+   defaulting to `/mnt/nirvana/perforceExports/build/exports`
+ - `EXPORT_SEARCH_PATH_X86_64`: the package export location to search for the
+   latest version of the x86_64 images, defaulting to
+   `$EXPORTS_DIR/ni/rtos/rtos_nilinuxrt/official/export`.
+ - `EXPORT_SEARCH_PATH_ARMV7_A`: the package export location to search for the
+   latest version of the ARMv7-A images, defaulting to
+   `$EXPORTS_DIR/ni/nilr/nilrt_os_common/official/export`.
+
+There is no way to select a particular version to be searched for; the script
+will always pick the version with the latest timestamp. This may be frustrating
+if work is ongoing for multiple versions. If you would like to change this
+behavior, modify the functions `get_latest_x86_64_images` and
+`get_latest_armv7_a_images`.
+
+### Software requirements
+Running the script requires QEMU (for x86_64 guests) and an SSH client to be
+available. The VM is started without graphics, so a display is not required. The
+TCP port 2222 is used to communicate with the guest. On Debian, the packages can
+be installed with:
+
+    apt-get install qemu openssh-client
+
+### Output format
+As with the platform-specific scripts, the output is a TSV table on standard
+output; however, the first column (the name of the image) is omitted as they
+are fetched as part of operation and aren't part of what the user is after.
+
+Additional messages are printed to standard error; they can be suppressed by
+setting the `VERBOSE` environment variable to `false`.
+
+### QEMU arguments
+The script does not invoke QEMU with any acceleration arguments, so it might be
+slower than you'd prefer. You can set the environment variable `QEMU_OPTIONS` to
+pass extra arguments. For instance, if you want to use KVM, you can use
+
+    QEMU_OPTIONS="-accel kvm" ./estimate-usage.sh
+
+### VM image
+When the script retrieves the disk image for the VM, by default it will copy it
+to `$XDG_CACHE_HOME/nilrt-estimate-usage/vm-base.qcow2` to be a courteous
+network user and speed up future runs of the script. There are no checks
+performed to detemine if the image is stale. You can set the `USE_CACHE`
+environment variable to `false` to force a download, but that will not clear the
+cache.

--- a/scripts/dev/estimate-usage/estimate-usage.armv7-a.runmode.sh
+++ b/scripts/dev/estimate-usage/estimate-usage.armv7-a.runmode.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+print_fs_usage() {
+    local image="$1"
+    # Format the UBI volume and create a clean ubifs...
+    ubimkvol /dev/ubi0 -N mynandvol -m >/dev/null
+    # ...reserving zero space for the root, similar to the cRIO-9068
+    mkfs.ubifs -R 0 /dev/ubi0_0
+    local mountpoint="$(mktemp -d)"
+    mount -t ubifs ubi0 "$mountpoint"
+    tar -xOf "$image" ./data.tar.gz | tar -xz -C "$mountpoint"
+    sync
+    echo -ne "$image\tARMv7-A\trunmode\tdisk footprint\t"
+    df -h "$mountpoint" | tail -1 | awk '{ print $3; }'
+    umount "$mountpoint"
+    rmdir "$mountpoint"
+    ubirmvol /dev/ubi0 -N mynandvol
+}
+
+# Simulate a Micron MT29F8G08ADBDA NAND flash with four partitions
+# like the cRIO-9068 configuration, with the last rootfs partition
+# around 942 MB.
+modprobe nandsim \
+    first_id_byte=0x2c  \
+    second_id_byte=0xa3 \
+    third_id_byte=0xd1  \
+    fourth_id_byte=0x15 \
+    parts=1,88,560
+
+modprobe ubi mtd=3
+
+modprobe ubifs
+
+if test 0 -eq $#; then
+    print_fs_usage /dev/stdin
+else
+    for image in "$@"; do
+        print_fs_usage "$image"
+    done
+fi
+
+rmmod ubifs
+rmmod ubi
+rmmod nandsim

--- a/scripts/dev/estimate-usage/estimate-usage.armv7-a.safemode.sh
+++ b/scripts/dev/estimate-usage/estimate-usage.armv7-a.safemode.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+print_fs_usage() {
+    local input_image="$1"
+    local image="$input_image"
+    if test ! -f "$image"; then
+        # We need to look at its filesize and read it multiple times, so if it's
+        # not a plain file, we should make it into one.
+        image="$(mktemp)"
+        cat "$input_image" >"$image"
+    fi
+    echo -ne "$image\tARMv7-A\tsafemode\tdisk footprint\t"
+    du --apparent-size -h "$image" | awk '{ print $1; }'
+    echo -ne "$image\tARMv7-A\tsafemode\tkernel + ramdisk\t"
+    local kernel_size="$(dumpimage "$image" -T flat_dt -p 0 -o /dev/fd/3 3>&1 >/dev/null | gzip -d | wc -c)"
+    local ramdisk_size="$(dumpimage "$image" -T flat_dt -p 16 -o /dev/fd/3 3>&1 >/dev/null | xz -d | wc -c)"
+    numfmt --to=iec "$(($kernel_size + $ramdisk_size))"
+    if test "$input_image" != "$image"; then
+        rm "$image"
+    fi
+}
+
+if test 0 -eq $#; then
+    print_fs_usage /dev/stdin
+else
+    for image in "$@"; do
+        print_fs_usage "$image"
+    done
+fi

--- a/scripts/dev/estimate-usage/estimate-usage.sh
+++ b/scripts/dev/estimate-usage/estimate-usage.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+set -e
+
+HERE="$(dirname "$(realpath "$0")")"
+
+EXPORTS_DIR="${EXPORTS_DIR-/mnt/nirvana/perforceExports/build/exports}"
+
+VM_DIR="${VM_DIR-/mnt/argo/RnD/RTOS/qemu_vms}"
+VM_DISK="$VM_DIR/${VM_ARMV7_A-debian_with_ssh_forwarding_mtd_utils.qcow2}"
+USE_CACHE="${USE_CACHE-true}"
+TMP_VM_DISK="$(mktemp)"
+
+RUNIMAGE="$(mktemp)"
+SAFEIMAGE="$(mktemp)"
+
+# If desirable, user can provide extra options for the QEMU invocation, but
+# it's not always the case that they have permissions to use KVM.
+#QEMU_OPTIONS="-accel kvm"
+
+VERBOSE="${VERBOSE-true}"
+log() {
+    $VERBOSE && echo "$@" >&2 || true
+}
+
+cleanup() {
+    rm "$TMP_VM_DISK"
+    rm "$RUNIMAGE" "$SAFEIMAGE"
+    kill %-
+}
+trap cleanup EXIT
+
+SSH_OPTIONS="-q -o StrictHostKeyChecking=no -o UpdateHostKeys=no"
+
+identify_latest() {
+    local latest_majmin="$(ls -t "$2" | head -1)"
+    local latest_export="$(ls -t "$2/$latest_majmin" | head -1)"
+    log "Latest export under $2 is $latest_export"
+    echo "$2/$latest_majmin/$latest_export"
+}
+
+wait_for_ssh() {
+    log "Attempting SSH connection..."
+    until ssh -p 2222 $SSH_OPTIONS root@localhost true; do
+        sleep 1
+        log "Retrying SSH connection..."
+    done
+}
+
+get_latest_x86_64_images() {
+    local default="$EXPORTS_DIR/ni/rtos/rtos_nilinuxrt/official/export"
+    local search="${EXPORT_SEARCH_PATH_X86_64-$default}"
+    local latest="$(identify_latest "$1" "$search")"
+    local presuffix="targets/linuxU/x64/gcc-4.7-oe/release"
+    local run_suffix="$presuffix/nilrt-base-system-image-x64.tar"
+    local safe_suffix="$presuffix/standard_x64_safemode.tar.gz"
+    cp -f "$latest/$run_suffix" "$1"
+    cp -f "$latest/$safe_suffix" "$2"
+}
+
+get_latest_armv7_a_images() {
+    local default="$EXPORTS_DIR/ni/nilr/nilrt_os_common/official/export"
+    local search="${EXPORT_SEARCH_PATH_ARMV7_A-$default}"
+    local latest="$(identify_latest "$1" "$search")"
+    local run_presuffix="distribution-systemlink_dkms/release/RT Images/SystemLink"
+    # There's a versioned directory here for some reason, but at least it's the
+    # only thing there and we can just use head -1 to get it.
+    run_presuffix="$run_presuffix/$(ls "$latest/$run_presuffix" | head -1)"
+    local run_suffix="$run_presuffix/systemlink-linux-armv7-a.tar"
+    local safe_suffix="crio_zynq_safemode.itb"
+    cp -f "$latest/$run_suffix" "$1"
+    cp -f "$latest/$safe_suffix" "$2"
+}
+
+if "$USE_CACHE"; then
+    CACHE_DIR="${XDG_CACHE_HOME-$HOME/.cache}/nilrt-estimate-usage"
+    if test ! -f "$CACHE_DIR/vm-base.qcow2"; then
+        log "Retrieving disk image into cache"
+        mkdir -p "$CACHE_DIR"
+        cp -f "$VM_DISK" "$CACHE_DIR/vm-base.qcow2"
+    fi
+    log "Creating disk image backed by cached image"
+    qemu-img create -q -f qcow2 -b "$CACHE_DIR/vm-base.qcow2" -F qcow2 "$TMP_VM_DISK"
+else
+    log "Retrieving disk image"
+    cp -f "$VM_DISK" "$TMP_VM_DISK"
+fi
+
+log "Starting VM"
+qemu-system-x86_64 \
+    "$TMP_VM_DISK" \
+    -m 512 \
+    -display none \
+    -netdev user,id=fwd,hostfwd=::2222-:22 -device e1000,netdev=fwd \
+    $QEMU_OPTIONS &
+log "VM PID is $(jobs -p %-)"
+wait_for_ssh
+
+log "Copying x86_64 scripts into VM"
+scp -P 2222 $SSH_OPTIONS "$HERE/estimate-usage.x86_64.runmode.sh" root@localhost:.
+scp -P 2222 $SSH_OPTIONS "$HERE/estimate-usage.x86_64.safemode.sh" root@localhost:.
+get_latest_x86_64_images "$RUNIMAGE" "$SAFEIMAGE"
+log "Running x86_64 subscripts in VM"
+cat "$RUNIMAGE" | ssh -p 2222 $SSH_OPTIONS root@localhost ./estimate-usage.x86_64.runmode.sh | cut -d $'\t' -f 2-
+cat "$SAFEIMAGE" | ssh -p 2222 $SSH_OPTIONS root@localhost ./estimate-usage.x86_64.safemode.sh | cut -d $'\t' -f 2-
+
+log "Copying ARMv7-A scripts into VM"
+scp -P 2222 $SSH_OPTIONS "$HERE/estimate-usage.armv7-a.runmode.sh" root@localhost:.
+scp -P 2222 $SSH_OPTIONS "$HERE/estimate-usage.armv7-a.safemode.sh" root@localhost:.
+get_latest_armv7_a_images "$RUNIMAGE" "$SAFEIMAGE"
+log "Running ARMv7-A subscripts in VM"
+cat "$RUNIMAGE" | ssh -p 2222 $SSH_OPTIONS root@localhost ./estimate-usage.armv7-a.runmode.sh | cut -d $'\t' -f 2-
+cat "$SAFEIMAGE" | ssh -p 2222 $SSH_OPTIONS root@localhost ./estimate-usage.armv7-a.safemode.sh | cut -d $'\t' -f 2-

--- a/scripts/dev/estimate-usage/estimate-usage.x86_64.runmode.sh
+++ b/scripts/dev/estimate-usage/estimate-usage.x86_64.runmode.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+print_fs_usage() {
+    local image="$1"
+    local fs="$(mktemp)"
+    truncate -s 2G "$fs"
+    mkfs.ext4 -q "$fs"
+    local mountpoint="$(mktemp -d)"
+    mount -o loop "$fs" "$mountpoint"
+    tar -xOf "$image" data.tar.gz | tar -xz -C "$mountpoint"
+    sync
+    echo -ne "$image\tx86_64\trunmode\tdisk footprint\t"
+    df -h "$mountpoint" | tail -1 | awk '{ print $3; }'
+    umount "$mountpoint"
+    rmdir "$mountpoint"
+    rm "$fs"
+}
+
+if test 0 -eq $#; then
+    print_fs_usage /dev/stdin
+else
+    for image in "$@"; do
+        print_fs_usage "$image"
+    done
+fi

--- a/scripts/dev/estimate-usage/estimate-usage.x86_64.safemode.sh
+++ b/scripts/dev/estimate-usage/estimate-usage.x86_64.safemode.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+print_fs_usage() {
+    local image="$1"
+    local fs="$(mktemp)"
+    truncate -s 1G "$fs"
+    mkfs.ext4 -q "$fs"
+    local mountpoint="$(mktemp -d)"
+    mount -o loop "$fs" "$mountpoint"
+    tar -xzf "$image" -C "$mountpoint"
+    sync
+    echo -ne "$image\tx86_64\tsafemode\tdisk footprint\t"
+    df -h "$mountpoint" | tail -1 | awk '{ print $3; }'
+    echo -ne "$image\tx86_64\tsafemode\tkernel + ramdisk\t"
+    local kernel_size="$(du -b "$mountpoint/bzImage" | awk '{ print $1; }')"
+    local ramdisk_size="$(xz -d <"$mountpoint/ramdisk.xz" | wc -c)"
+    numfmt --to=iec "$(($kernel_size + $ramdisk_size))"
+    umount "$mountpoint"
+    rmdir "$mountpoint"
+    rm "$fs"
+}
+
+if test 0 -eq $#; then
+    print_fs_usage /dev/stdin
+else
+    for image in "$@"; do
+        print_fs_usage "$image"
+    done
+fi


### PR DESCRIPTION
These Bash scripts allow developers to predict approximate disk usage for runmode and safemode images.

More information can be found in the added README.

Output of `./estimate-usage.sh` (tab stops at 12 columns for clarity):

    x86_64      runmode     disk footprint          911M
    x86_64      safemode    disk footprint          40M
    x86_64      safemode    kernel + ramdisk        173M
    ARMv7-A     runmode     disk footprint          151M
    ARMv7-A     safemode    disk footprint          26M
    ARMv7-A     safemode    kernel + ramdisk        108M

On a PXIe-8880, after formatting the disk via MAX, extracting the x86_64 runmode image via SSH results in 899.4M of disk space used.
On a cRIO-9067, after formatting the disk via MAX, extracting the ARMv7-A runmode image via SSH results in 146M of disk space used.

I believe the discrepancy arises from the contents of `/boot`, which the estimations script do not exclude but real targets extract to a different filesystem. The size of that directory is roughtly corresponding to the discrepancy (~10M and ~5M for x86_64 and ARMv7-A).

[AB#1978832](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1978832)