### PR TITLE
[hardknott] CHANGELOG: Merge 8.X release information into hardknott

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,50 +103,8 @@ Branch: `nilrt/22.5/hardknott`
 - [Removed](https://github.com/ni/meta-nilrt/pull/355) boot attestation based on now dead upstream code.
 - [Removed](https://github.com/ni/meta-nilrt/pull/290) packages dropped from upstream.
 
-----
-
-## 8.11
-Branch: `nilrt/21.8/sumo`
-
-The 8.11 release is a regular, quarterly release of NI LinuxRT. It primarily contains bug fixes to the OE-sumo-based release images. Most development was performed in 2022 Q1.
-
-
-### nilrt
-
-#### Added
-- [Added](https://github.com/ni/nilrt/pull/117) a `CONTRIBUTING` file with a Developer Certificate of Origin agreement.
-
-#### Fixed
-- Audited recipes throughout the meta-layers and, where needed, switched the github recipe source lines to use `https` as their transport protocol. This accommodated GitHub deprecating their `git` transport endpoints.
-
-
-### meta-nilrt
-
-#### Changed
-- [Upgraded](https://github.com/ni/meta-nilrt/pull/288) `opkg` to version `0.5.0`.
-- [Moved](https://github.com/ni/meta-nilrt/pull/327) `tbb` from the `extra/` feed to `main/`.
-- [Upgraded](https://github.com/ni/linux/pull/59) the `linux` kernel from `5.10.83-rt58` to `5.10.106-rt64`.
-    - [Fixed](https://github.com/ni/linux/commit/051c9569fc919a173fbc7a56c75efdbba3b13b8c) [an issue](https://github.com/ni/linux/issues/44) in `buildnipkg` which prohibited booting on roboRIO-2.0.
-
-#### Fixed
-- [Fixed](https://github.com/ni/meta-nilrt/pull/320) a `busybox` incompatibility in the `update-ca-certificates` script.
-- [Fixed](https://github.com/ni/meta-nilrt/pull/326) NILRT's static uid/gid assignments to deconflict static assignments from colliding with dynamically created accounts.
-- [Fixed](https://github.com/ni/meta-nilrt/pull/332) a build failure in the `libxkbcommon` package. It, and the rest of the `qtbase` dependencies should now be provided in the `main/` package feed.`
-
-
-### openembedded-core
-
-### Changed
-- [Upgraded](https://github.com/ni/openembedded-core/pull/39) `opkg` and `opkg-utils` to version `0.5.0`.
-    - `libsolv` upgraded to `0.7.17`.
-- [Upgraded](https://github.com/ni/openembedded-core/pull/42) `ca-certificates` to `20211016` to resolve a revoked Mozilla DST certificate which caused malformed codepaths to execute in openssl.
-
-### Fixed
-- [Fixed](https://github.com/ni/openembedded-core/pull/48) kernel modules being errantly marked as configuration files in opkg.
-
 
 ----
-
 
 ## 8.12
 Branch: `nilrt/22.5/sumo`
@@ -172,8 +130,7 @@ The 8.12 release is a regular, quarterly release of NI LinuxRT. It primarily con
 - [Fixed](https://github.com/ni/openembedded-core/pull/59) an issue where opkg's stderr output ends up in opkg status file.
 
 
----
-
+----
 
 ## 8.11
 Branch: `nilrt/21.8/sumo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@ The 8.11 release is a regular, quarterly release of NI LinuxRT. It primarily con
 - [Upgraded](https://github.com/ni/meta-nilrt/pull/288) `opkg` to version `0.5.0`.
 - [Moved](https://github.com/ni/meta-nilrt/pull/327) `tbb` from the `extra/` feed to `main/`.
 - [Upgraded](https://github.com/ni/linux/pull/59) the `linux` kernel from `5.10.83-rt58` to `5.10.106-rt64`.
+    - [Fixed](https://github.com/ni/linux/commit/051c9569fc919a173fbc7a56c75efdbba3b13b8c) [an issue](https://github.com/ni/linux/issues/44) in `buildnipkg` which prohibited booting on roboRIO-2.0.
 
 #### Fixed
 - [Fixed](https://github.com/ni/meta-nilrt/pull/320) a `busybox` incompatibility in the `update-ca-certificates` script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The NI Linux Real-Time project uses a mainline branching model with product bran
 
 This changelog attempts to conform to the changelog spec on [keepachangelog.org](https://keepachangelog.com/en/1.0.0/).
 
+The evergreen, canonical changelog for *all NILRT branches* can be [found here](https://github.com/ni/nilrt/blob/HEAD/CHANGELOG.md).
+
 To see changes to each individual package in the core feed, check out the [feed changelog](/docs/feed-changelog.md)
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,47 @@ The 8.11 release is a regular, quarterly release of NI LinuxRT. It primarily con
 
 ----
 
+## 8.11
+Branch: `nilrt/21.8/sumo`
+
+The 8.11 release is a regular, quarterly release of NI LinuxRT. It primarily contains bug fixes to the OE-sumo-based release images. Most development was performed in 2022 Q1.
+
+
+### nilrt
+
+#### Added
+- [Added](https://github.com/ni/nilrt/pull/117) a `CONTRIBUTING` file with a Developer Certificate of Origin agreement.
+
+#### Fixed
+- Audited recipes throughout the meta-layers and, where needed, switched the github recipe source lines to use `https` as their transport protocol. This accommodated GitHub deprecating their `git` transport endpoints.
+
+
+### meta-nilrt
+
+#### Changed
+- [Upgraded](https://github.com/ni/meta-nilrt/pull/288) `opkg` to version `0.5.0`.
+- [Moved](https://github.com/ni/meta-nilrt/pull/327) `tbb` from the `extra/` feed to `main/`.
+- [Upgraded](https://github.com/ni/linux/pull/59) the `linux` kernel from `5.10.83-rt58` to `5.10.106-rt64`.
+
+#### Fixed
+- [Fixed](https://github.com/ni/meta-nilrt/pull/320) a `busybox` incompatibility in the `update-ca-certificates` script.
+- [Fixed](https://github.com/ni/meta-nilrt/pull/326) NILRT's static uid/gid assignments to deconflict static assignments from colliding with dynamically created accounts.
+- [Fixed](https://github.com/ni/meta-nilrt/pull/332) a build failure in the `libxkbcommon` package. It, and the rest of the `qtbase` dependencies should now be provided in the `main/` package feed.`
+
+
+### openembedded-core
+
+### Changed
+- [Upgraded](https://github.com/ni/openembedded-core/pull/39) `opkg` and `opkg-utils` to version `0.5.0`.
+    - `libsolv` upgraded to `0.7.17`.
+- [Upgraded](https://github.com/ni/openembedded-core/pull/42) `ca-certificates` to `20211016` to resolve a revoked Mozilla DST certificate which caused malformed codepaths to execute in openssl.
+
+### Fixed
+- [Fixed](https://github.com/ni/openembedded-core/pull/48) kernel modules being errantly marked as configuration files in opkg.
+
+
+----
+
 ## 8.10
 Branch: `nilrt/21.5/sumo`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,18 @@ Branch: `nilrt/22.5/hardknott`
 
 ----
 
+## 8.13
+
+Branch: `nilrt/22.8/sumo`
+
+### nilrt
+
+#### Fixed
+- [Fixed](https://github.com/ni/nilrt/commit/979c1003) an error in the extra feed build pipeline script which referenced the wrong recipe name.
+
+
+----
+
 ## 8.12
 Branch: `nilrt/22.5/sumo`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ Branch: `nilrt/22.5/hardknott`
 
 Branch: `nilrt/22.8/sumo`
 
+The 8.13 release is a regular release of the NI LinuxRT "sumo" mainline, supporting all ARM32 hardware.
+
 ### nilrt
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,34 @@ The 8.11 release is a regular, quarterly release of NI LinuxRT. It primarily con
 
 ----
 
+
+## 8.12
+Branch: `nilrt/22.5/sumo`
+
+The 8.12 release is a regular, quarterly release of NI LinuxRT. It primarily contains minor improvements and bug fixes to OE-sumo-based release images.
+
+
+### nilrt
+
+#### Added
+- [Added](https://github.com/ni/nilrt/pull/142) pyrex support so that builds happen in a container.
+
+
+### meta-nilrt
+
+#### Changed
+- [Updated](https://github.com/ni/meta-nilrt/pull/395) default machine to `xilinx-zynq`
+
+
+### openembedded-core
+
+#### Fixed
+- [Fixed](https://github.com/ni/openembedded-core/pull/59) an issue where opkg's stderr output ends up in opkg status file.
+
+
+---
+
+
 ## 8.11
 Branch: `nilrt/21.8/sumo`
 


### PR DESCRIPTION
It's getting to be burdensome to cherry-pick changes between the hardknott and sumo mainlines, and also to their release branches. We missed integrating some 8.X release information into hardknott already, and I think it will be confusing for users to determine which changelog they should be looking at.

So I'd like to adopt a policy of only using the latest mainline (in this case, "hardknott") as the canonical CHANGELOG and having all other branches just reference the github URL for the main changelog, rather than keeping their own copies.

`https://github.com/ni/nilrt/blob/HEAD/CHANGELOG.md`

As a first step, this PR merges the missing 8.X release information into the hardknott changelog, and also adds release information for 8.13.

Next, I'll add a line to the top of the sumo changelogs to direct users to the *canonical* changelog.