### PR TITLE
[hardknott] README: Fix incorrect package index name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
 
 7. #### Building various images
 
-    **NOTE** You must build packagefeed-ni-core and package_index first to build images.
+    **NOTE** You must build packagefeed-ni-core and package-index first to build images.
 
     * Build a safemode image by running the following command:
 


### PR DESCRIPTION
Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

The README refers to package_index instead of package-index. Fixing that.