### PR TITLE
[sumo] Updated README and container scripts for external builders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,18 @@ Build Steps
         git submodule init
         git submodule update --remote --checkout
 
-2. Set up your shell environment to run bitbake:
+2. [Install the docker engine](https://docs.docker.com/engine/install/) on your build host.
+    If you can successfully run `docker run hello-world`, then you have everything you should need.
+
+3.    Build (or pull) the `build-nilrt` pyrex container image.
+        ```bash
+        bash ./docker/create-build-nilrt.sh  # will tag the image as build-nilrt:${NILRT_codename}
+
+        # Verification
+        docker images build-nilrt  # should print the image you just built
+        ```
+
+3. Set up your shell environment to run bitbake:
 
     Source NILRT's environment script by running the following command:
 
@@ -44,11 +55,16 @@ of NILRT for your hardware.
     **NOTE** It's not recommended to run bitbake for different
 MACHINE's in the same workspace (build directory).
 
-3. Build the package or packages that you want for your target.
+4. Build the package or packages that you want for your target.
 For example, to build Python, Ruby, and Apache for Zynq targets, run the
 following commands:
 
         bitbake python ruby apache2
+
+    **NOTE** Some packages may have updated their default branch naming such that it no longer matches the expected value.
+    This can be fixed by updating the `SRC_URI` variable for the package to add a `branch` value.
+
+        SRC_URI = "git://github.com/fedora-sysv/initscripts;protocol=https;branch=main"
 
     To build every package in National Instruments' feed, run the
 following commands:
@@ -70,7 +86,7 @@ the following directory:
 
         tmp-glibc/deploy/ipk/...
 
-4. (Optional/Advanced) Bitbake can transform tmp-glibc/deploy/ipk/ into
+5. (Optional/Advanced) Bitbake can transform tmp-glibc/deploy/ipk/ into
 a package feed when you run the following command:
 
         bitbake package-index
@@ -86,7 +102,7 @@ to other hosts on your local network. You may need to configure your
 firewall to permit Python to access port 8080. Otherwise, the server
 will only be accessible locally on address localhost:8080.
 
-5. (Optional/Advanced) Build a bootable recovery disk by running the
+6. (Optional/Advanced) Build a bootable recovery disk by running the
 following commands:
 
         bitbake restore-mode-image

--- a/docker/create-build-nilrt.sh
+++ b/docker/create-build-nilrt.sh
@@ -45,12 +45,21 @@ pushd "${SCRIPT_ROOT}"
 short_hash=$(git rev-parse --short HEAD)
 popd
 
+# parse the NIRLT codename from the meta-nilrt:layer.conf
+NILRT_codename=$(grep -e '^LAYERSERIES_COMPAT_meta-nilrt' "${SCRIPT_ROOT}/../sources/meta-nilrt/conf/layer.conf" | cut -d'"' -f2)
+if [ -z "$NILRT_codename" ]; then
+	echo "ERROR: could not parse NILRT_codename from the meta-nilrt layer." >&2
+	exit 1
+else
+	echo "INFO: using NILRT_codename=${NILRT_codename}"
+fi
+
 
 set -e
 # build the pyrex base image
 docker build \
 	-f "${PYREX_ROOT}/image/Dockerfile" \
-	-t "pyrex-base:sumo" \
+	-t "pyrex-base:${NILRT_codename}" \
 	--build-arg=PYREX_BASE=$PYREX_BASE \
 	"${PYREX_ROOT}/image"
 
@@ -58,13 +67,13 @@ docker build \
 docker build \
 	-f "${SCRIPT_ROOT}/build-nilrt.Dockerfile" \
 	-t "${IMAGE_NAME}:${short_hash}" \
-	--build-arg=PYREX_IMAGE=pyrex-base:sumo \
+	--build-arg=PYREX_IMAGE=pyrex-base:${NILRT_codename} \
 	"${SCRIPT_ROOT}"
 
-# tag the image as 'latest'
+# tag the image with the NILRT codename
 docker tag \
 	"${IMAGE_NAME}:${short_hash}" \
-	"${IMAGE_NAME}:latest"
+	"${IMAGE_NAME}:${NILRT_codename}"
 
 # optionally tag it with the branch name
 if [ -n "${tag_branch}" ]; then


### PR DESCRIPTION
Currently the instructions for building sumo don't work for external builds due to changes and the addition of pyrex to the sumo branch. These fixes bring the README and container creation scripts more in-line with expected behavior.
- Updated the `create-build-nilrt.sh` script to tag the container with the branch codename instead of `latest`.
- Updated the README to include steps necessary for pyrex and a comment on potential upstream branch name changes.

## Testing:
Built the core and extra package groups locally without the `--org` flag. 