### PR TITLE
Add script to diff CVE .csv files

### DIFF
--- a/scripts/dev/diff-cve-csvs.py
+++ b/scripts/dev/diff-cve-csvs.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python3
+
+import argparse
+import csv
+from pprint import pprint
+
+def get_cves(filename):
+    with open(filename, newline='') as fp:
+        dialect = None
+        try:
+            dialect = csv.Sniffer().sniff(fp.read(1024), delimiters=",\t;")
+        except csv.Error:
+            dialect = "excel"
+            pass
+        fp.seek(0)
+
+        reader = csv.reader(fp, dialect)
+        global headings
+        headings = next(reader)
+        rows = [dict(zip(headings, line)) for line in reader]
+        # Each cve entry in the dict is a dict of packages it appears in,
+        # and the corresponding entries from the csv
+        cves = {}
+        for row in rows:
+            cve = row["id"]
+            package_name = row["package_name"]
+            if cve not in cves.keys():
+                cves[cve] = {}
+            cves[cve][package_name] = row
+        return cves
+
+parser = argparse.ArgumentParser(description="Parse the CVEs in the"
+    " given csv files and generate diff information")
+parser.add_argument("csv1", help="Filename of the latest csv file")
+parser.add_argument("csv2", help="Filename of the older csv file")
+parser.add_argument("--output_file", default = "new_cves_introduced.csv")
+
+args = parser.parse_args()
+
+# Compare new to old, get what was added, changed and removed.
+# We only write what was added to the csv file.
+
+parsed_new_cves = get_cves(args.csv1)
+parsed_old_cves = get_cves(args.csv2)
+
+new_cves_added = {}
+existing_cves_added_to_new_pkg = {}
+removed_cves = {}
+for cve in parsed_new_cves:
+    if cve not in parsed_old_cves:
+        new_cves_added[cve] = parsed_new_cves[cve]
+    else:
+        # check if the cve has been added to any packages
+        for package in parsed_new_cves[cve]:
+            if package not in parsed_old_cves[cve]:
+                existing_cves_added_to_new_pkg[cve] = parsed_new_cves[cve][package]
+
+for cve in parsed_old_cves:
+    if cve not in parsed_new_cves:
+        removed_cves[cve] = parsed_old_cves[cve]
+
+with open(args.output_file, 'w', newline='') as fp:
+    writer = csv.DictWriter(fp, fieldnames=headings)
+    writer.writeheader()
+    for row in new_cves_added:
+        for package in new_cves_added[row]:
+            writer.writerow(new_cves_added[row][package])
+
+
+#print("new_cves_added")
+#pprint(new_cves_added)
+#print("existing_cves_added_to_new_pkg")
+#pprint(existing_cves_added_to_new_pkg)
+#print("removed_cves")
+#pprint(removed_cves)
+
+


### PR DESCRIPTION
We would like to track the CVEs added in a new release, in addition to tracking all the CVEs every release. 
Add a script that generates the diff of two csv files and writes it to a csv file.

AzDO [2131135](https://ni.visualstudio.com/DevCentral/_workitems/edit/2131135)