### PR TITLE
estimate-usage: Use alphabetically latest export

### DIFF
--- a/scripts/dev/estimate-usage/README.md
+++ b/scripts/dev/estimate-usage/README.md
@@ -66,10 +66,9 @@ the searching starts:
    `$EXPORTS_DIR/ni/nilr/nilrt_os_common/official/export`.
 
 There is no way to select a particular version to be searched for; the script
-will always pick the version with the latest timestamp. This may be frustrating
-if work is ongoing for multiple versions. If you would like to change this
-behavior, modify the functions `get_latest_x86_64_images` and
-`get_latest_armv7_a_images`.
+will pick the latest export (according to NI's export versioning scheme) from
+latest release. If you would like to change this behavior, modify the functions
+`get_latest_x86_64_images` and `get_latest_armv7_a_images`.
 
 ### Software requirements
 Running the script requires QEMU (for x86_64 guests) and an SSH client to be

--- a/scripts/dev/estimate-usage/estimate-usage.sh
+++ b/scripts/dev/estimate-usage/estimate-usage.sh
@@ -33,8 +33,8 @@ trap cleanup EXIT
 SSH_OPTIONS="-q -o StrictHostKeyChecking=no -o UpdateHostKeys=no"
 
 identify_latest() {
-    local latest_majmin="$(ls -t "$2" | head -1)"
-    local latest_export="$(ls -t "$2/$latest_majmin" | head -1)"
+    local latest_majmin="$(ls -r "$2" | head -1)"
+    local latest_export="$(ls -t "$2/$latest_majmin" | sed 'y/dabf/wxyz/' | sort -rV | sed 'y/wxyz/dabf/' | head -1)"
     log "Latest export under $2 is $latest_export"
     echo "$2/$latest_majmin/$latest_export"
 }


### PR DESCRIPTION
Use alphabetically latest export instead of chronologically latest so that touching an old folder wouldn't result in wrong export being selected.

Someone seems to have touched 22.0 folder (or created, deleted a file in that folder) in last couple of days which resulted in it being selected as latest export causing pipeline failure (as image names didn't match expectations).

### Testing
`ls -r | head -1` results in latest export being selected.