### PR TITLE
scripts/pipelines: Adding script to log build versions.

### DIFF
--- a/scripts/pipelines/log-buildversions.sh
+++ b/scripts/pipelines/log-buildversions.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# This script creates a file documenting the commits
+# used to during the most recent build. The file
+# includes both the commits used by AUTOREV packages
+# and the commits used for the git submodules.
+
+SCRIPT_ROOT=$(realpath $(dirname $BASH_SOURCE))
+
+function usage() {
+    cat <<EOF
+$(basename $0) [-h] [-a]
+
+Get information on the specific commit versions for NILRT components after a build.
+
+# Options
+-h
+    Print this message and exit.
+-a
+    Include all SRCREVs and not just AUTOREVs.
+EOF
+}
+
+buildhistory_opts=
+while getopts ":ho:a" opt; do
+    case $opt in
+        h )
+            usage >&1
+            exit 0
+            ;;
+        a )
+            buildhistory_opts="-a"
+            ;;
+        \? )
+            echo "ERROR: Invalid option -${OPTARG}." >&2
+            exit 1
+            ;;
+    esac
+done
+shift $(($OPTIND - 1))
+
+# Gets nilrt and submodule repo hashes.
+function get_repo_hashes() {
+    local nilrt_rev=$(git rev-parse HEAD)
+    local submodule_status=$(git submodule status)
+    cat <<EOF
+# git repo hashes for nilrt and submodules.
+# Checkout these commits to use the same versions as this build.
+nilrt commit id: $nilrt_rev
+
+# Submodules
+$submodule_status
+EOF
+}
+
+# Gets SRCREV values from the OE buildhistory.
+function get_rev_commits() {
+    local buildhistory_dir=buildhistory/
+    if [ -d buildhistory/ ]; then
+        local buildhistory_output="$(buildhistory-collect-srcrevs ${buildhistory_opts})"
+        cat <<EOF
+# Build revisions used for recipes. Copy into local.conf or a similar
+# global conf file to staple to the same revisions used for this build.
+$buildhistory_output
+EOF
+    else
+        >&2 echo "ERROR: No buildhistory directory at $buildhistory_dir. Make sure a build with buildhistory enabled occured."
+        exit 1
+    fi
+}
+
+. "${SCRIPT_ROOT}/build.common.sh" > /dev/null
+
+REPO_HASHES="$(get_repo_hashes)"
+ACTUALREVS="$(get_rev_commits)"
+
+echo "$REPO_HASHES"
+echo
+echo "$ACTUALREVS"


### PR DESCRIPTION
Currently, there's not an easy way to share what versions a build used for reproducing a configuration. This adds a script that logs the repo, submodule, and AUTOREV commit hashes for use in pipelines.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

## Note to reviewers:
This script is intended to be used in AzDO pipelines so that a file documenting the build versions can be included in the daily build feed exports. This will allow more easily checking what commits are in an export and easier reproducibility of the builds when needed for debugging purposes.

I plan to:
- Add usage of this script to the AzDO build pipelines/makefiles.
- Eventually add a script that will interpret the log file output and apply it locally instead of requiring manual copying.

## Testing:
Enabled buildhistory on my dev machine and built, then ran the script. Example output:
```
INFO: Using /home/charlie/nilrt/build as the OE build workspace.
INFO: BB_NUMBER_THREADS not set. Calculating...
BB_NUMBER_THREADS=32
INFO: Using pyrex image: build-nilrt:hardknott
BitBake Build Tool Core version 1.50.0
INFO: Entered bitbake environment.

# git repo hashes for nilrt and submodules.
# Checkout these commits to use the same versions as this build.
nilrt commit id: fa94f75e58082d17fa401f0d0be532b61659e2c8

# Submodules
+ef7f75210849819314ee73a81b604ddc69a9efeb ../sources/bitbake (yocto-3.3.4-27-gef7f7521)
+8ef451727e0263ea0474c0066d40b86e7523e5b5 ../sources/meta-cloud-services (RELEASE_NILRT_2022Q3)
+daec228933c40a35350d7bddd1d123293483b219 ../sources/meta-nilrt (remotes/origin/nilrt/master/hardknott)
+f0459b14619b3cc324b96fc041755630beba5dda ../sources/meta-openembedded (RELEASE_NILRT_2022Q3-38-gf0459b1461)
+c251b45d3f34120ebdf5b0160b49f75fea1e0c50 ../sources/meta-qt5 (5.2.1+origin/release-840-gc251b45)
+9afbfb070a35f8173ff69c2447bc7691f6a1e784 ../sources/meta-qt5-extra (RELEASE_NILRT_2022Q3)
+5c8538bfd023cf247c280cc0e87ffa3774aa41cf ../sources/meta-rauc (RELEASE_NILRT_2022Q3-2-g5c8538b)
+dc029749c402127315b6f0768b88370b1b93f01a ../sources/meta-sdr (RELEASE_NILRT_2022Q3-6-gdc02974)
+c40e1e84da9624b9096a463dbed3b301c01c268e ../sources/meta-security (RELEASE_NILRT_2022Q3)
+46fd3b881b617b2d445289d90163d3712e38111e ../sources/meta-selinux (RELEASE_NILRT_2022Q3)
+e423dc4d662d7577d230734a656381f3427b8a6a ../sources/meta-virtualization (RELEASE_NILRT_2022Q3)
+308697cf0d042d359730c01a2310671daeb1fe29 ../sources/openembedded-core (yocto-3.3.6-202-g308697cf0d)
+f07e184bff80684ff37cace257aa841d0d225e4f ../sources/pyrex (v1.6.0-10-gf07e184)

# Build revisions used for recipes. Copy into local.conf or a similar
# global conf file to staple to the same revisions used for this build.
# core2-64-nilrt-linux
SRCREV_pn-crda = "47b1aaa36e770be587c33f0f5345fe8df550aabc"
SRCREV_qtbase_pn-qtbase = "40143c189b7c1bf3c2058b77d00ea5c4e3be8b28"
SRCREV_pn-salt = "fe2a17b8b65e3aef21a963c6477ae73827ac5002"
# x64-nilrt-linux
SRCREV_pn-linux-nilrt = "b91848330161799938aca2d5ef5666300add6a6c"
SRCREV_pn-linux-nilrt-nohz = "b91848330161799938aca2d5ef5666300add6a6c"
# x86_64-linux
SRCREV_qtbase_pn-qtbase-native = "40143c189b7c1bf3c2058b77d00ea5c4e3be8b28"
```