### PR TITLE
Update pyrex container for kirkstone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "sources/meta-nilrt"]
 	path = sources/meta-nilrt
 	url = ../meta-nilrt.git
-	branch = nilrt/master/hardknott
+	branch = nilrt/master/kirkstone
 [submodule "sources/meta-selinux"]
 	path = sources/meta-selinux
 	url = ../meta-selinux.git

--- a/docker/create-build-nilrt.sh
+++ b/docker/create-build-nilrt.sh
@@ -3,7 +3,7 @@ set -u
 
 SCRIPT_ROOT=$(realpath $(dirname ${BASH_SOURCE}))
 PYREX_ROOT=$(realpath "${SCRIPT_ROOT}/../sources/pyrex")
-PYREX_BASE=ubuntu-20.04-oe
+PYREX_BASE=ubuntu-22.04-oe
 
 IMAGE_NAME=build-nilrt
 


### PR DESCRIPTION
Update .gitmodules to use `nilrt/master/kirkstone` for `meta-nilrt`
Update `create-build-nilrt.sh` to use `ubuntu-22.04-oe` as base.

### Testing
Ran `create-build-nilrt.sh` and verified `build-nilrt:kirkstone` was built.
`/etc/os-release` in `pyrex-shell` confirms Ubuntu 22.04.

Used this container to build poky's `core-image-minimal` with latest bitbake (2.2) without issues.