### PR TITLE
gitmodules: add meta-xilinx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,6 +66,10 @@
 	path = sources/meta-rauc
 	url = ../meta-rauc.git
 	branch = nilrt-academic/master/sumo
+[submodule "sources/meta-xilinx"]
+	path = sources/meta-xilinx
+	url = ../meta-xilinx.git
+	branch = nilrt-academic/master/sumo
 [submodule "sources/pyrex"]
 	path = sources/pyrex
 	url = ../pyrex.git


### PR DESCRIPTION
The meta-xilinx layer provides BSP support for the qemu-zynq7 machine type. The NILRT-Academic development team needs this machine to enable generation of the FRC images using QEMU.

Add the ni/meta-xilinx repo to the git submodules.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

This PR enables [meta-nilrt #469](https://github.com/ni/meta-nilrt/pull/469).

# Testing
Trivial.