### PR TITLE
scripts/pipelines: Create script for building meta-toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
 
     These scripts are also a good source for understanding the steps to build a package feed manually. Note that if you are building package feeds *manually*, you must bitbake the special `package-index` target before using the feed.
 
+    * ##### Building the cross-compile toolchain
+        One of these pipelines can build the cross-compile toolchain. By default, it builds for x86_64 Linux hosts.
+
+        ```bash
+        bash ../scripts/pipelines/build.toolchain.sh
+        ```
+
+        During the build, a script is generated at `$BUILDDIR/tmp-glibc/deploy/sdk`, with a name like `oecore-x86_64-core2-64-toolchain-9.2.sh`. The script is a self-extracting archive, and can be copied to and executed on an appropriate host system to install the toolchain.
+
 7. #### Building various images
 
     **NOTE** You must build packagefeed-ni-core and package-index first to build images.

--- a/scripts/pipelines/build.toolchain.sh
+++ b/scripts/pipelines/build.toolchain.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+SCRIPT_ROOT=$(realpath $(dirname $BASH_SOURCE))
+
+. "${SCRIPT_ROOT}/build.common.sh" "$@"
+
+echo "INFO: Building meta-toolchain"
+bitbake meta-toolchain


### PR DESCRIPTION
This creates a simple script to easily allow building of the cross-compile toolchain, similar to the other scripts used for pipelines.

Note: running the build may be dependent on ni/meta-nilrt#494.

[AB#1242721](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1242721)