### PR TITLE
Revert "Removing meta-mingw layer"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,10 @@
 	path = sources/openembedded-core
 	url = ../openembedded-core.git
 	branch = nilrt/master/hardknott
+[submodule "sources/meta-mingw"]
+	path = sources/meta-mingw
+	url = ../meta-mingw.git
+	branch = nilrt/master/hardknott
 [submodule "sources/meta-virtualization"]
 	path = sources/meta-virtualization
 	url = ../meta-virtualization.git


### PR DESCRIPTION
This reverts commit 68a63c8. This layer is needed to build an SDK cross-compiling toolchain for Windows.

AzDO [2105299](https://ni.visualstudio.com/DevCentral/_workitems/edit/2105299)