### PR TITLE
[academic/sumo] Use codename for tagging academic Docker image

### DIFF
--- a/docker/create-build-nilrt.sh
+++ b/docker/create-build-nilrt.sh
@@ -45,12 +45,21 @@ pushd "${SCRIPT_ROOT}"
 short_hash=$(git rev-parse --short HEAD)
 popd
 
+# parse the NIRLT codename from the meta-nilrt:layer.conf
+NILRT_codename=$(grep -e '^LAYERSERIES_COMPAT_meta-nilrt' "${SCRIPT_ROOT}/../sources/meta-nilrt/conf/layer.conf" | cut -d'"' -f2)
+if [ -z "$NILRT_codename" ]; then
+	echo "ERROR: could not parse NILRT_codename from the meta-nilrt layer." >&2
+	exit 1
+else
+	echo "INFO: using NILRT_codename=${NILRT_codename}"
+fi
+
 
 set -e
 # build the pyrex base image
 docker build \
 	-f "${PYREX_ROOT}/image/Dockerfile" \
-	-t "pyrex-base:sumo" \
+	-t "pyrex-base:${NILRT_codename}" \
 	--build-arg=PYREX_BASE=$PYREX_BASE \
 	"${PYREX_ROOT}/image"
 
@@ -58,13 +67,13 @@ docker build \
 docker build \
 	-f "${SCRIPT_ROOT}/build-nilrt.Dockerfile" \
 	-t "${IMAGE_NAME}:${short_hash}" \
-	--build-arg=PYREX_IMAGE=pyrex-base:sumo \
+	--build-arg=PYREX_IMAGE=pyrex-base:${NILRT_codename} \
 	"${SCRIPT_ROOT}"
 
-# tag the image as 'latest'
+# tag the image with the NILRT codename
 docker tag \
 	"${IMAGE_NAME}:${short_hash}" \
-	"${IMAGE_NAME}:latest"
+	"${IMAGE_NAME}:${NILRT_codename}"
 
 # optionally tag it with the branch name
 if [ -n "${tag_branch}" ]; then

--- a/docker/create-build-nilrt.sh
+++ b/docker/create-build-nilrt.sh
@@ -51,6 +51,7 @@ if [ -z "$NILRT_codename" ]; then
 	echo "ERROR: could not parse NILRT_codename from the meta-nilrt layer." >&2
 	exit 1
 else
+	NILRT_codename="academic-${NILRT_codename}"
 	echo "INFO: using NILRT_codename=${NILRT_codename}"
 fi
 


### PR DESCRIPTION
The build automation work for [AB#1986796](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1986796) uses this script to create the container, but the version in the academic mainline does not use the codename to tag its Docker images as the other branches do.

This change cherry-picks the change to do so, but also *prefixes the codename* with `academic-` for uniqueness.