### PR TITLE
repos: re-add meta-mingw to upstream sources list

### DIFF
--- a/scripts/dev/upstream_merge/repos.conf
+++ b/scripts/dev/upstream_merge/repos.conf
@@ -11,3 +11,4 @@ sources/meta-qt5             https://github.com/meta-qt5/meta-qt5               
 sources/meta-qt5-extra       https://github.com/schnitzeltony/meta-qt5-extra       hardknott             nilrt/master/hardknott
 sources/meta-rauc            https://github.com/rauc/meta-rauc                     hardknott             nilrt/master/hardknott
 sources/pyrex                https://github.com/garmin/pyrex                       master                nilrt/master/hardknott
+sources/meta-mingw           https://git.yoctoproject.org/meta-mingw               hardknott             nilrt/23.0/hardknott


### PR DESCRIPTION
It shouldn't be missing as the submodule is there and we keep track of the changes.