### PR TITLE
repos: add meta-mingw upstream to merge list

### DIFF
--- a/scripts/dev/upstream_merge/repos.conf
+++ b/scripts/dev/upstream_merge/repos.conf
@@ -11,3 +11,4 @@ sources/meta-qt5             https://github.com/meta-qt5/meta-qt5               
 sources/meta-qt5-extra       https://github.com/schnitzeltony/meta-qt5-extra       hardknott             nilrt/master/hardknott
 sources/meta-rauc            https://github.com/rauc/meta-rauc                     hardknott             nilrt/master/hardknott
 sources/pyrex                https://github.com/garmin/pyrex                       master                nilrt/master/hardknott
+sources/meta-mingw           https://git.yoctoproject.org/meta-mingw               hardknott             nilrt/master/hardknott


### PR DESCRIPTION
The meta-mingw submodule was removed and re-added, but upon re-adding, the upstream listing in repos.conf was NOT re-added.

This adds the upstream ref so that the merge script will work with it.