### PR TITLE
pyrex.ini: Set '--security-opt seccomp=unconfined'

### DIFF
--- a/scripts/azdo/conf/pyrex.ini
+++ b/scripts/azdo/conf/pyrex.ini
@@ -101,6 +101,8 @@ envvars =
 # Extra arguments to pass when running the image. For example:
 #   --mount type=bind,src=${env:HOME}/.ssh,dst=${env:HOME}/.ssh,readonly
 #   --device /dev/kvm
+args =
+	--security-opt seccomp=unconfined
 
 # Prefix for all Pyrex commands. Useful for debugging. For example:
 #   strace -ff -ttt -o strace.log --


### PR DESCRIPTION
This is needed for building kirkstone feeds on build agents with old libseccomp.

Azdo WI: [2105148](https://dev.azure.com/ni/DevCentral/_workitems/edit/2105148)

### Testing
PR build pipeline builds OE with these changes.