### PR TITLE
repos: set upstream for meta-qt5-extra to master

### DIFF
--- a/scripts/dev/upstream_merge/repos.conf
+++ b/scripts/dev/upstream_merge/repos.conf
@@ -8,7 +8,7 @@ sources/meta-virtualization  https://git.yoctoproject.org/meta-virtualization   
 sources/meta-security        https://git.yoctoproject.org/meta-security            kirkstone             nilrt/master/kirkstone
 sources/meta-sdr             https://github.com/balister/meta-sdr                  kirkstone             nilrt/master/kirkstone
 sources/meta-qt5             https://github.com/meta-qt5/meta-qt5                  kirkstone             nilrt/master/kirkstone
-sources/meta-qt5-extra       https://github.com/schnitzeltony/meta-qt5-extra       kirkstone             nilrt/master/kirkstone
+sources/meta-qt5-extra       https://github.com/schnitzeltony/meta-qt5-extra       master                nilrt/master/kirkstone
 sources/meta-rauc            https://github.com/rauc/meta-rauc                     kirkstone             nilrt/master/kirkstone
 sources/pyrex                https://github.com/garmin/pyrex                       master                nilrt/master/kirkstone
 sources/meta-mingw           https://git.yoctoproject.org/meta-mingw               kirkstone             nilrt/master/kirkstone


### PR DESCRIPTION
There is no kirkstone branch of meta-qt5-extra in upstream, and we know that it should be master already. The initial commit adding the upstream, 62e0a4f, had this error in it.

Testing: upstream_merge.sh would exit and halt because it could not find a remote branch (there is no kirkstone branch for meta-qt5-extra). After making the changes, the script works as expected.