### PR TITLE
Revert "Add upstream hashserver for internal builds."

### DIFF
--- a/scripts/azdo/conf/ni-org.conf
+++ b/scripts/azdo/conf/ni-org.conf
@@ -16,12 +16,4 @@ PRSERV_HOST = "versionator2.amer.corp.natinst.com:8585"
 #
 # Internal feed configuration.
 #
-NILRT_FEEDS_URI ?= "http://nickdanger.natinst.com/feeds"
-
-#
-# Internal hashserver configuration.
-#
-#
-BB_SIGNATURE_HANDLER = "OEEquivHash"
-BB_HASHSERVE = "auto"
-BB_HASHSERVE_UPSTREAM = "rtosams.amer.corp.natinst.com:8687"
+NILRT_FEEDS_URI ?= "http://nickdanger.amer.corp.natinst.com/feeds"


### PR DESCRIPTION
This reverts commit ccb0eb5d95431ad9610b6d5f15c8aa67af3bdd6c.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

## Testing: 
N/A. This should have no discernable impact other than disabling the hash equivalency server.