### PR TITLE
[hardknott] Revert "Add upstream hashserver for internal builds."

### DIFF
--- a/scripts/azdo/conf/ni-org.conf
+++ b/scripts/azdo/conf/ni-org.conf
@@ -17,11 +17,3 @@ PRSERV_HOST = "versionator.amer.corp.natinst.com:8585"
 # Internal feed configuration.
 #
 NILRT_FEEDS_URI ?= "http://nickdanger.natinst.com/feeds"
-
-#
-# Internal hashserver configuration.
-#
-#
-BB_SIGNATURE_HANDLER = "OEEquivHash"
-BB_HASHSERVE = "auto"
-BB_HASHSERVE_UPSTREAM = "rtosams.amer.corp.natinst.com:8687"


### PR DESCRIPTION
This reverts commit ccb0eb5d95431ad9610b6d5f15c8aa67af3bdd6c.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>