### PR TITLE
[kirkstone] auto.conf: Enable cve-check

### DIFF
--- a/scripts/azdo/conf/auto.conf
+++ b/scripts/azdo/conf/auto.conf
@@ -5,7 +5,7 @@ BUILDHISTORY_COMMIT = "1"
 
 # Generates a "cve/cve.log" in every recipe's work dir.
 # https://wiki.yoctoproject.org/wiki/How_do_I#Q:_How_do_I_get_a_list_of_CVEs_patched.3F
-#INHERIT += "cve-check"
+INHERIT += "cve-check"
 
 # The buildstats class records performance statistics about each task executed
 # during the build (e.g. elapsed time, CPU usage, and I/O usage).


### PR DESCRIPTION
Currently, running a build with cve-check enabled requires a developer to manually do so in a local build. This change enables the option for auto-builds so that the results are exported consistently.

[AB#2328022](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2328022)

## Testing:
N/A. Testing will be performed by an autobuild after this is submitted.