### PR TITLE
[kirkstone] Revert "auto.conf: Enable cve-check"

### DIFF
--- a/scripts/azdo/conf/auto.conf
+++ b/scripts/azdo/conf/auto.conf
@@ -5,7 +5,7 @@ BUILDHISTORY_COMMIT = "1"
 
 # Generates a "cve/cve.log" in every recipe's work dir.
 # https://wiki.yoctoproject.org/wiki/How_do_I#Q:_How_do_I_get_a_list_of_CVEs_patched.3F
-INHERIT += "cve-check"
+#INHERIT += "cve-check"
 
 # The buildstats class records performance statistics about each task executed
 # during the build (e.g. elapsed time, CPU usage, and I/O usage).


### PR DESCRIPTION
This reverts commit 35cb7382b2b2f08516eefcd61d06446ae9142cd7.

A change upstream in kirkstone causes builds with both BUILD_IMAGES_FROM_FEEDS and cve-check to fail (see commit 291024f in openembedded-core). Instead of enabling the cve-check for all builds including images, it will need to be enabled in our internal feed build configurations.