### PR TITLE
[hardknott] cve-to-csv.py: Handle multiline fields in CVE files.

### DIFF
--- a/scripts/pipelines/cve-to-csv.py
+++ b/scripts/pipelines/cve-to-csv.py
@@ -2,6 +2,7 @@
 from argparse import ArgumentParser
 from pathlib import Path
 import os
+import re
 import sys
 
 
@@ -35,8 +36,8 @@ class CVE():
     @staticmethod
     def from_stanza(stanza: str):
         cve = CVE()
-        for line in stanza:
-            stanza_key, value = line.split(':', maxsplit=1)
+        for entry in stanza:
+            stanza_key, value = entry.split(':', maxsplit=1)
             value = value.strip()
             if len(value) == 0:
                 value = None
@@ -61,17 +62,12 @@ for root, dirs, fils in os.walk(args.cve_directory):
         sys.stderr.write(f'Processing CVE file: {fil} ')
         cve_file = os.path.join(root, fil)
         with open(cve_file, 'r') as fp_cve:
-            stanza_lines = []
-            for line in fp_cve.readlines():
-                line = line.strip()
-                if len(line) > 0:
-                    stanza_lines.append(line)
-                elif len(stanza_lines) > 0:
-                    new_cve = CVE.from_stanza(stanza_lines)
-                    sys.stderr.write('.')
-                    cves.append(new_cve)
-                else:
-                    continue
+            cve_entries = re.findall(r"^LAYER:[\s\S]*?(?=^LAYER:|\n*\Z)", fp_cve.read(), re.MULTILINE)
+            for cve in cve_entries:
+                stanza_lines = re.findall(r'^.*:[\s\S]*?(?=\n+^.*:|\n*\Z)', cve, re.MULTILINE)
+                new_cve = CVE.from_stanza(stanza_lines)
+                sys.stderr.write('.')
+                cves.append(new_cve)
         sys.stderr.write('\n')
 
 


### PR DESCRIPTION
When including cve-check, CVE entries are pulled from an online database which we don't control. Some entries in the database recently had new lines in the description which caused the script to convert all the CVE files to a CSV file to fail.

This change updates the script to parse the CVE files using regexes instead of line by line.

[AB#2371060](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2371060)

**Note:** This will need cherry-picked into kirkstone as well.

## Testing: 
Built locally to get CVE files which were failing (openssl + openssl-native), then ran the script. Here is a sample CSV output.
[cve.csv](https://github.com/ni/nilrt/files/11276207/cve.csv)