### PR TITLE
[hardknott] cve-to-csv.py: Update regex to explicitly look for keys.

### DIFF
--- a/scripts/pipelines/cve-to-csv.py
+++ b/scripts/pipelines/cve-to-csv.py
@@ -64,7 +64,8 @@ for root, dirs, fils in os.walk(args.cve_directory):
         with open(cve_file, 'r') as fp_cve:
             cve_entries = re.findall(r"^LAYER:[\s\S]*?(?=^LAYER:|\n*\Z)", fp_cve.read(), re.MULTILINE)
             for cve in cve_entries:
-                stanza_lines = re.findall(r'^.*:[\s\S]*?(?=\n+^.*:|\n*\Z)', cve, re.MULTILINE)
+                keys = '|'.join(CVE.FIELDS.keys())
+                stanza_lines = re.findall(rf'^(?:{keys}):[\s\S]*?(?=\n+^(?:{keys}):|\n*\Z)', cve, re.MULTILINE)
                 new_cve = CVE.from_stanza(stanza_lines)
                 sys.stderr.write('.')
                 cves.append(new_cve)


### PR DESCRIPTION
The regex used to parse fields in CVE files was failing when text in the description matched the key filter. This change updates the regex to only check for known key values explicitly.

[AB#2377202](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2377202)

## Testing done: 
Built packagefeed-ni-core locally with cve-check enabled, then ran the script to output the CSV. Example CSV here:
[cve.csv](https://github.com/ni/nilrt/files/11336323/cve.csv)