### PR TITLE
[kirkstone] Updates to kernel readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,6 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
 
     These scripts are also a good source for understanding the steps to build a package feed manually. Note that if you are building package feeds *manually*, you must bitbake the special `package-index` target before using the feed.
 
-    * ##### Building the cross-compile toolchain
-        One of these pipelines can build the cross-compile toolchain. By default, it builds for x86_64 Linux hosts.
-
-        ```bash
-        bash ../scripts/pipelines/build.toolchain.sh
-        ```
-
-        During the build, a script is generated at `$BUILDDIR/tmp-glibc/deploy/sdk`, with a name like `oecore-x86_64-core2-64-toolchain-9.2.sh`. The script is a self-extracting archive, and can be copied to and executed on an appropriate host system to install the toolchain.
-
 7. #### Building various images
 
     **NOTE** You must build packagefeed-ni-core and package-index first to build images.
@@ -149,6 +140,17 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
         Boot your NI Linux Real-Time compatible hardware from the recovery media and follow on-screen instructions to perform a factory reset.
 
     **NOTE** By default, National Instruments software is pulled from a feed hosted on ni.com. You can redirect to a mirror by setting IPK_NI_SUBFEED_URI to any URI supported by opkg in your org.conf,site.conf, or auto.conf.
+
+8. #### Building the cross-compile toolchain
+
+    In order to compile custom packages for NI Linux Real-Time on a host system, a cross-compile toolchain is necessary. This can be built directly
+    from one of the scripts in the [`:scripts/pipelines/`](https://github.com/ni/nilrt/tree/HEAD/scripts/pipelines) directory. By default, it builds for x86_64 Linux hosts.
+
+    ```bash
+    bash ../scripts/pipelines/build.toolchain.sh
+    ```
+
+    During the build, a script is generated at `$BUILDDIR/tmp-glibc/deploy/sdk`, with a name like `oecore-x86_64-core2-64-toolchain-9.2.sh`. The script is a self-extracting archive, and can be copied to and executed on an appropriate host system to install the toolchain.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
 
     During the build, a script is generated at `$BUILDDIR/tmp-glibc/deploy/sdk`, with a name like `oecore-x86_64-core2-64-toolchain-9.2.sh`. The script is a self-extracting archive, and can be copied to and executed on an appropriate host system to install the toolchain.
 
+    To build the toolchain for an x86_64 Windows host, there is a different script that can be used.
+    
+    ```bash
+    bash ../scripts/pipelines/build.cross-toolchain.sh
+    ```
+
+    During the build, an archive is generated at `$BUILDDIR/tmp-glibc/deploy/sdk`, with a name like
+    `oecore-x86_64-core2-64-toolchain.tar.xz`. This archive can be extracted on a Windows system to
+    to access the toolchain.
+
 ---
 
     Enjoy, and happy hacking!

--- a/docs/README.kernel.md
+++ b/docs/README.kernel.md
@@ -231,10 +231,10 @@ KERNEL_VERSION=`make -s kernelrelease`
    issue), the `/boot/runmode/bzImage` path used by the bootloader is
    not a symbolic link, but rather the kernel itself. To avoid
    overwriting the known-good kernel, rename it appropriately by running
-   this command on the target:
+   this command:
 
    ```bash
-   test ! -h /boot/runmode/bzImage && mv /boot/runmode/bzImage /boot/runmode/bzImage-`uname -r`
+   ssh admin@$TARGET "test ! -h /boot/runmode/bzImage && mv /boot/runmode/bzImage /boot/runmode/bzImage-`uname -r`"
    ```
 
 2. Copy the new kernel to the target with SSH.
@@ -243,10 +243,10 @@ KERNEL_VERSION=`make -s kernelrelease`
    scp arch/x86/boot/bzImage admin@$TARGET:/boot/runmode/bzImage-$KERNEL_VERSION
    ```
 
-   On the target, rewrite the symlink used by the bootloader.
+   Rewrite the symlink used by the bootloader.
 
    ```bash
-   ln -sf bzImage-$KERNEL_VERSION /boot/runmode/bzImage
+   ssh admin@$TARGET ln -sf bzImage-$KERNEL_VERSION /boot/runmode/bzImage
    ```
 
 3. Copy the kernel modules to the target.
@@ -267,19 +267,19 @@ KERNEL_VERSION=`make -s kernelrelease`
    provides an interactive menu to choose whether to boot into safemode:
 
    ```bash
-   fw_setenv bootdelay 5
+   ssh admin@$TARGET fw_setenv bootdelay 5
    ```
 
 5. Reboot the target.
 
    ```bash
-   reboot
+   ssh admin@$TARGET reboot
    ```
 
 6. (optional) Check version of the updated kernel on the target.
 
    ```bash
-   uname -r
+   ssh admin@$TARGET uname -r
    ```
 
 

--- a/docs/README.kernel.md
+++ b/docs/README.kernel.md
@@ -153,11 +153,12 @@ You can use any cross-compilation toolchain of your choosing, or you can
 download the toolchains from ni.com, or build them yourself.
 
 The toolchains are available for download:
- - x86_64: http://www.ni.com/download/labview-real-time-module-2014/4959/en/
- - armv7-a: http://www.ni.com/download/labview-real-time-module-2014/4957/en/
+ - [GNU C & C++ Compile Tools x64](https://www.ni.com/en-us/support/downloads/software-products/download.gnu-c---c---compile-tools-x64.html)
+ - [GNU C & C++ Compile Tools for ARMv7](https://www.ni.com/en-us/support/downloads/software-products/download.gnu-c---c---compile-tools-for-armv7.html)
 
-Refer to the README to get started with building OpenEmbedded
-components, and build the NILRT SDK containing a GCC toolchain.
+Refer to the [README](../README.md) to get started with building
+OpenEmbedded components and [building the NILRT SDK](../README.md#building-the-cross-compile-toolchain)
+containing a GCC toolchain.
 
 The README describes how to build SDKs for both Linux and Windows
 machines. Building the kernel is presently only supported on Linux.

--- a/docs/README.kernel.md
+++ b/docs/README.kernel.md
@@ -325,6 +325,12 @@ KERNEL_VERSION=`make -s kernelrelease`
 
 ## Rebuilding NI out-of-tree Drivers with DKMS
 
+In this section, these variables will be used:
+
+```bash
+TARGET=<the target's hostname or IP address>
+```
+
 ### Transferring the Kernel Source to the Target
 
 DKMS needs access to the kernel headers/config/source in order to
@@ -342,19 +348,19 @@ over the network, saving limited disk space resources.
    sudo systemctl start sshd
    ```
 
-2. Install sshfs on the target.
+2. Install sshfs on the target and load the module for fuse.
 
    ```bash
-   opkg update
-   opkg install sshfs-fuse
+   ssh admin@$TARGET "opkg update && opkg install sshfs-fuse"
+   ssh admin@$TARGET modprobe fuse
    ```
 
-3. Mount the kernel source on the target.
+3. Mount the kernel source on the target. Note that user and host
+   in this case are the values for the host build machine.
 
    ```bash
-   mkdir /usr/src/linux
-   modprobe fuse
-   sshfs <user>@<host>:<path_to_kernel_source> /usr/src/linux
+   ssh admin@$TARGET mkdir /usr/src/linux
+   ssh admin@$TARGET sshfs <user>@<host>:<path_to_linux_source> /usr/src/linux
    ```
 
 #### With `scp` and `tar`
@@ -368,6 +374,13 @@ tar cz --exclude=./.git --exclude=$TEMP_MODULES . | ssh admin@$TARGET tar xz --n
 ```
 
 ### Using the Source with DKMS
+
+The following steps are all run on the target. This can be done either by
+opening an ssh session as below or through a serial connection.
+
+```bash
+ssh admin@$TARGET
+```
 
 1. Fix dangling build and source symlinks.
 

--- a/docs/README.kernel.md
+++ b/docs/README.kernel.md
@@ -285,13 +285,29 @@ KERNEL_VERSION=`make -s kernelrelease`
 
 ### ARM32 Targets
 
-1. Set the kernel configuration to match NI’s settings.
+#### Building the kernel 
 
-   ```bash
-   export ARCH=arm
-   export CROSS_COMPILE=/path/to/toolchain/usr/bin/arm-nilrt-linux-gnueabi/arm-nilrt-linux-gnueabi-
-   make nati_zynq_defconfig
-   ```
+1. Create the configuration for the kernel.
+
+   - Make sure the appropriate environment variables are set for cross compilation:
+
+     ```bash
+     export ARCH=arm
+     export CROSS_COMPILE=/path/to/toolchain/usr/bin/arm-nilrt-linux-gnueabi/arm-nilrt-linux-gnueabi-
+     ```
+
+   - Start with a configuration matching NI's settings:
+
+     ```bash
+     make nati_zynq_defconfig
+     ```
+
+   - If it is desirable to adjust the kernel configuration (this is uncommon),
+     the menuconfig target can be used to open a curses interface:
+
+     ```bash
+     make menuconfig
+     ```
 
 2. Compile the kernel.
 
@@ -299,28 +315,36 @@ KERNEL_VERSION=`make -s kernelrelease`
    make ni-pkg
    ```
 
-3. Copy the new kernel to the target.
+#### Installing the kernel
+
+In this section, these variables will be used:
+
+```bash
+TARGET=<the target's hostname or IP address>
+```
+
+1. Copy the new kernel to the target.
 
    ```bash
-   scp ni-install/arm/boot/ni_zynq_custom_runmodekernel.itb admin@<target>:/boot/linux_runmode.itb
+   scp ni-install/arm/boot/ni_zynq_custom_runmodekernel.itb admin@$TARGET:/boot/linux_runmode.itb
    cd ni-install/arm/lib/modules/
-   tar cz lib | ssh admin@<target> tar xz -C /
+   tar cz lib | ssh admin@$TARGET tar xz -C /
    ```
 
    Note that the build and source symlinks in the modules directory do
    not need to be copied over to the target. The `tar` command above
    will not follow the symlinks.
 
-5. Reboot the target.
+2. Reboot the target.
 
    ```bash
-   reboot
+   ssh admin@$TARGET reboot
    ```
 
-6. (optional) Check version of the updated kernel on the target.
+3. (optional) Check version of the updated kernel on the target.
 
    ```bash
-   uname -r
+   ssh admin@$TARGET uname -r
    ```
 
 ## Rebuilding NI out-of-tree Drivers with DKMS

--- a/docs/README.kernel.md
+++ b/docs/README.kernel.md
@@ -408,13 +408,12 @@ tar cz --exclude=./.git --exclude=$TEMP_MODULES . | ssh admin@$TARGET tar xz --n
 8. Reboot the target.
 
 
-**HELP! MY TARGET DOESN'T BOOT!**
+## Target Doesn't Boot the Kernel
 
-If, after building and putting a new kernel on the target, you are unable
+If after building and putting a new kernel on the target you are unable
 to boot successfully, refer to your controller's documentation on forcing
 the controller to boot into safe mode and format from MAX.
 
-*** NOTE ***
-Changes to the kernel running on the target will be lost in certain operations
-from MAX, including formatting the target and uninstalling all components.
-
+> **Note**
+> Changes to the kernel running on the target will be lost in certain operations
+> from MAX, including formatting the target and uninstalling all components.


### PR DESCRIPTION
After reviewing the kernel build instructions, there were several minor updates that could be made. This included:
- Updating toolchain build instructions in README.md to include Windows toolchains
- Updating the links to get toolchain downloads in the kernel readme
- Updating tone and language for troubleshooting if something doesn't boot after a kernel update
- Add ssh to commands that need to run on the target
- Update the ARM build instructions to be in line with the x64 instructions.

[AB#2308610](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2308610)

## Testing
Ran through the complete instructions for x64 and confirmed they worked.