### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ Additional community documentation can be found at https://nilrt-docs.ni.com.
 
 ### Mainlines
 
-This project currently has four concurrent development mainlines (sorry). They are, in short:
-* `nilrt/master/hardknott` - the current **x64** dev HEAD
-* `nilrt/master/kirkstone` - the next-major **x64** rebase HEAD
+This project currently has three concurrent development mainlines (sorry). They are, in short:
+* `nilrt/master/kirkstone` - the current **x64** dev HEAD
 * `nilrt/master/sumo` - the current **arm32** dev HEAD
 * `nilrt-academic/master/sumo` - a forked **arm32** HEAD for [FIRST Robotics Competition](https://www.firstinspires.org/robotics/frc)
 


### PR DESCRIPTION
Cyclic update of the README. Not much to change besides the list of active branches and the note about OpenSSH's SHA1 deprecation.

[AB#2401963](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2401963)