### PR TITLE
Improve graphical support in QEMU start script

### DIFF
--- a/scripts/pipelines/vm-resources/runQemuVM.sh
+++ b/scripts/pipelines/vm-resources/runQemuVM.sh
@@ -96,7 +96,7 @@ fi
 SCRIPT_DIR="`dirname "$BASH_SOURCE[0]"`"
 set -x
 qemu-system-x86_64 \
-	${enableKVM:-} -cpu qemu64 -smp cpus=${cpu_count:-1} \
+	${enableKVM:-} -cpu qemu64 -smp cpus=${cpu_count:-1} -machine vmport=off \
 	-m "${mem_mbs:-${VM_MEM_SIZE_MB}}" \
 	-nographic \
 	-drive if=pflash,format=raw,readonly,file="$SCRIPT_DIR/OVMF/OVMF_CODE.fd" \


### PR DESCRIPTION
As noted in [AB#2503092](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2503092), a segmentation fault is currently encountered when attempting to run NILRT in a QEMU VM with `ui.enabled=True`. This occurs in `X`, using the `/usr/lib/xorg/modules/input/vmmouse_drv.so` library, in the function `VMMouseProtoInOut`; it is written in assembly and attempts to interact with an IO port with an [`inl %dx, %eax` instruction][1].

The [`qemu(1)` manpage][2] has this text describing its `-machine` options:
> vmport=on|off|auto  
> Enables emulation of VMWare IO port, for vmmouse etc. auto says to select the value based on accel. For accel=xen the default is off otherwise the default is on.

I haven't investigated why the [vmmouse driver][3] fails. Since disabling that port prevents the issue, it may be a QEMU bug with emulating that port.

<details><summary>Debugging info for reference</summary>
<p>

 - QEMU version: 8.1.1
 - opkg packages installed for debugging:
   - `gdb`
   - `xf86-input-vmmouse-{dbg,dev,src}`
   - `xinit-{dbg,dev,src}`
   - `xserver-xorg-{dbg,dev,src}`
 - GDB script used to chase down the segfault:
   ```
   set history file ~/X.gdb-log
   set history save on
   file /usr/bin/X
   add-symbol-file /usr/lib/xorg/modules/input/vmmouse_drv.so
   set directories /usr/src/debug/xserver-xorg/2_21.1.8-r0/xorg-server-21.1.8 /usr/src/debug/xf86-input-vmmouse/2_13.1.0-r0/xf86-input-vmmouse-13.1.0/src
   start :0
   b main.c:246 
   b xf86Init.c:745
   # b udev.c:452
   # ignore 4 10
   # b udev.c:291
   b xf86Xinput.c:968
   b vmmouse_client.c:66
   ```
 - GDB backtrace:
   ```
   #0  0x00007f289a77636b in VMMouseProtoInOut (cmd=0x5b529b) at ../../xf86-input-vmmouse-13.1.0/shared/vmmouse_proto.c:66
   #1  VMMouseProto_SendCmd (cmd=0x5b529b) at ../../xf86-input-vmmouse-13.1.0/shared/vmmouse_proto.c:150
   #2  0x00000000005a6548 in ?? ()
   #3  0x00007f289a776192 in VMMouseClientVMCheck () at ../../xf86-input-vmmouse-13.1.0/shared/vmmouse_client.c:66
   #4  VMMouseClient_Enable () at ../../xf86-input-vmmouse-13.1.0/shared/vmmouse_client.c:152
   #5  0x00007f289a775ea5 in VMMousePreInit (drv=<optimized out>, pInfo=0x17a7470, flags=<optimized out>) at ../../xf86-input-vmmouse-13.1.0/src/vmmouse.c:430
   #6  0x0000000000545990 in xf86NewInputDevice (pInfo=0x17a7470, pdev=pdev@entry=0x7ffe4a16e0e8, enable=<optimized out>) at ../xorg-server-21.1.8/hw/xfree86/common/xf86Xinput.c:968
   #7  0x00000000005468f6 in NewInputDeviceRequest (options=0x17a5b80, attrs=attrs@entry=0x7ffe4a16e0f0, pdev=pdev@entry=0x7ffe4a16e0e8) at ../xorg-server-21.1.8/hw/xfree86/common/xf86Xinput.c:1118
   #8  0x00000000005943ca in device_added (udev_device=udev_device@entry=0x17e5580) at ../xorg-server-21.1.8/config/udev.c:291
   #9  0x000000000059486b in config_udev_init () at ../xorg-server-21.1.8/config/udev.c:452
   #10 0x0000000000593799 in config_init () at ../xorg-server-21.1.8/config/config.c:50
   #11 0x0000000000539ae1 in InitInput (argc=argc@entry=2, argv=argv@entry=0x7ffe4a16e3f8) at ../xorg-server-21.1.8/hw/xfree86/common/xf86Init.c:745
   #12 0x0000000000466d5d in dix_main (argc=2, argv=0x7ffe4a16e3f8, envp=<optimized out>) at ../xorg-server-21.1.8/dix/main.c:246
   #13 0x00007f289aef057b in __libc_start_call_main (main=main@entry=0x42b350 <main>, argc=argc@entry=2, argv=argv@entry=0x7ffe4a16e3f8) at ../sysdeps/nptl/libc_start_call_main.h:58
   #14 0x00007f289aef0630 in __libc_start_main_impl (main=0x42b350 <main>, argc=2, argv=0x7ffe4a16e3f8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7ffe4a16e3e8) at ../csu/libc-start.c:389
   #15 0x000000000042b385 in _start () at ../sysdeps/x86_64/start.S:115
   ```

</p>
</details>

Besides disabling that vmport, this PR also adds an option to the script as a shortcut for adding arguments to better support graphical usage.

[1]: <https://www.felixcloutier.com/x86/in>
[2]: <https://www.qemu.org/docs/master/system/invocation.html>
[3]: <https://gitlab.freedesktop.org/xorg/driver/xf86-input-vmmouse>