### PR TITLE
[kirkstone] Improve diff-cve-csvs.py scripting

### DIFF
--- a/scripts/dev/diff-cve-csvs.py
+++ b/scripts/dev/diff-cve-csvs.py
@@ -2,72 +2,89 @@
 
 import argparse
 import csv
+import logging
 from pathlib import Path
 from pprint import pprint
 import sys
 
+logger = logging.getLogger("diff-cve-csvs.py")
 
-def get_cves(filename):
-    with open(filename, newline='') as fp:
-        dialect = None
-        try:
-            dialect = csv.Sniffer().sniff(fp.read(1024), delimiters=",\t;")
-        except csv.Error:
-            dialect = "excel"
-            pass
-        fp.seek(0)
 
-        reader = csv.reader(fp, dialect)
-        global headings
-        headings = next(reader)
-        rows = [dict(zip(headings, line)) for line in reader]
-        # Each cve entry in the dict is a dict of packages it appears in,
-        # and the corresponding entries from the csv
-        cves = {}
-        for row in rows:
-            cve = row["id"]
-            package_name = row["package_name"]
-            if cve not in cves.keys():
-                cves[cve] = {}
-            cves[cve][package_name] = row
-        return cves
+# field names, ordered as they will appear in the output files
+FIELD_NAMES = [
+    "id",
+    "layer",
+    "package_name",
+    "package_version",
+    "status",
+    "summary",
+    "score_v2",
+    "score_v3",
+    "vector",
+    "more_information",
+]
+
+
+def oe_cve_id(cve_data):
+    """In OpenEmbedded, the same CVE might appear assigned to multiple
+    packages. This method returns a fully-qualified ID, which includes
+    the package name."""
+    return "/".join([
+        cve_data["id"],
+        cve_data["package_name"],
+    ])
+
+def read_cve_summary(summary_filepath):
+    logger.info(f"Reading CVE summary CSV file: {summary_filepath}")
+    cves = {}
+    with open(summary_filepath, "r") as fp_summary:
+        reader = csv.DictReader(fp_summary)
+        for entry in reader:
+            id = oe_cve_id(entry)
+            if id in cves.keys():
+                logger.warning(f"Duplicate entry found for {id}. Only latest value will be used.")
+            cves[id] = entry
+    logger.info(f"Parsed {len(cves)} cves.")
+    return cves
+
+def iter_added_cves(old_cves, new_cves):
+    for new_cve in (new_cves.keys() - old_cves.keys()):
+        yield new_cves[new_cve]
+
+def write_cve_summary(file, cves):
+    writer = csv.DictWriter(file, FIELD_NAMES)
+    writer.writeheader()
+    writer.writerows(cves)
+    logger.info(f"Wrote {len(cves)} entries.")
     
+
 def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(description="Parse the CVEs in the given csv files and generate diff information")
     parser.add_argument("old_csv", type=Path, help="Path to the older csv file.")
     parser.add_argument("new_csv", type=Path, help="Path to the newer csv file")
-    parser.add_argument("-o", "--output-file", default="new_cves_introduced.csv")
+    parser.add_argument("-v", "--verbose", action="count")
 
     args = parser.parse_args(argv)
+
+    if args.verbose >= 2:
+        logging.basicConfig(level=logging.DEBUG)
+    elif args.verbose >= 1:
+        logging.basicConfig(level=logging.INFO)
 
     # Compare new to old, get what was added, changed and removed.
     # We only write what was added to the csv file.
 
-    parsed_new_cves = get_cves(args.new_csv)
-    parsed_old_cves = get_cves(args.old_csv)
+    old_cves = read_cve_summary(args.old_csv)
+    new_cves = read_cve_summary(args.new_csv)
 
-    new_cves_added = {}
-    existing_cves_added_to_new_pkg = {}
-    removed_cves = {}
-    for cve in parsed_new_cves:
-        if cve not in parsed_old_cves:
-            new_cves_added[cve] = parsed_new_cves[cve]
-        else:
-            # check if the cve has been added to any packages
-            for package in parsed_new_cves[cve]:
-                if package not in parsed_old_cves[cve]:
-                    existing_cves_added_to_new_pkg[cve] = parsed_new_cves[cve][package]
+    added_cves = list(iter_added_cves(old_cves, new_cves))
+    print(f"Found {len(added_cves)} added CVEs.")
+    if len(added_cves) > 0:
+        logger.info("Writing added_cves.csv file.")
+        with open("added_cves.csv", "w") as fp_added:
+            write_cve_summary(fp_added, added_cves)
 
-    for cve in parsed_old_cves:
-        if cve not in parsed_new_cves:
-            removed_cves[cve] = parsed_old_cves[cve]
-
-    with open(args.output_file, 'w', newline='') as fp:
-        writer = csv.DictWriter(fp, fieldnames=headings)
-        writer.writeheader()
-        for row in new_cves_added:
-            for package in new_cves_added[row]:
-                writer.writerow(new_cves_added[row][package])
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/dev/diff-cve-csvs.py
+++ b/scripts/dev/diff-cve-csvs.py
@@ -2,7 +2,10 @@
 
 import argparse
 import csv
+from pathlib import Path
 from pprint import pprint
+import sys
+
 
 def get_cves(filename):
     with open(filename, newline='') as fp:
@@ -28,50 +31,44 @@ def get_cves(filename):
                 cves[cve] = {}
             cves[cve][package_name] = row
         return cves
+    
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(description="Parse the CVEs in the given csv files and generate diff information")
+    parser.add_argument("old_csv", type=Path, help="Path to the older csv file.")
+    parser.add_argument("new_csv", type=Path, help="Path to the newer csv file")
+    parser.add_argument("-o", "--output-file", default="new_cves_introduced.csv")
 
-parser = argparse.ArgumentParser(description="Parse the CVEs in the"
-    " given csv files and generate diff information")
-parser.add_argument("csv1", help="Filename of the latest csv file")
-parser.add_argument("csv2", help="Filename of the older csv file")
-parser.add_argument("--output_file", default = "new_cves_introduced.csv")
+    args = parser.parse_args(argv)
 
-args = parser.parse_args()
+    # Compare new to old, get what was added, changed and removed.
+    # We only write what was added to the csv file.
 
-# Compare new to old, get what was added, changed and removed.
-# We only write what was added to the csv file.
+    parsed_new_cves = get_cves(args.new_csv)
+    parsed_old_cves = get_cves(args.old_csv)
 
-parsed_new_cves = get_cves(args.csv1)
-parsed_old_cves = get_cves(args.csv2)
+    new_cves_added = {}
+    existing_cves_added_to_new_pkg = {}
+    removed_cves = {}
+    for cve in parsed_new_cves:
+        if cve not in parsed_old_cves:
+            new_cves_added[cve] = parsed_new_cves[cve]
+        else:
+            # check if the cve has been added to any packages
+            for package in parsed_new_cves[cve]:
+                if package not in parsed_old_cves[cve]:
+                    existing_cves_added_to_new_pkg[cve] = parsed_new_cves[cve][package]
 
-new_cves_added = {}
-existing_cves_added_to_new_pkg = {}
-removed_cves = {}
-for cve in parsed_new_cves:
-    if cve not in parsed_old_cves:
-        new_cves_added[cve] = parsed_new_cves[cve]
-    else:
-        # check if the cve has been added to any packages
-        for package in parsed_new_cves[cve]:
-            if package not in parsed_old_cves[cve]:
-                existing_cves_added_to_new_pkg[cve] = parsed_new_cves[cve][package]
+    for cve in parsed_old_cves:
+        if cve not in parsed_new_cves:
+            removed_cves[cve] = parsed_old_cves[cve]
 
-for cve in parsed_old_cves:
-    if cve not in parsed_new_cves:
-        removed_cves[cve] = parsed_old_cves[cve]
-
-with open(args.output_file, 'w', newline='') as fp:
-    writer = csv.DictWriter(fp, fieldnames=headings)
-    writer.writeheader()
-    for row in new_cves_added:
-        for package in new_cves_added[row]:
-            writer.writerow(new_cves_added[row][package])
-
-
-#print("new_cves_added")
-#pprint(new_cves_added)
-#print("existing_cves_added_to_new_pkg")
-#pprint(existing_cves_added_to_new_pkg)
-#print("removed_cves")
-#pprint(removed_cves)
+    with open(args.output_file, 'w', newline='') as fp:
+        writer = csv.DictWriter(fp, fieldnames=headings)
+        writer.writeheader()
+        for row in new_cves_added:
+            for package in new_cves_added[row]:
+                writer.writerow(new_cves_added[row][package])
 
 
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This patchset makes some improvements to the `diff-cve-csvs.py` developer scripting, that devs use to compare the CVE summary files between iterations. In short, this patchset:
* Adds more verbosity to what the script is doing.
* Reorders the script's input arguments to be: old, then new.
* Reimplements the CSV reader/writer logic to use the `DictReader`/`DictWriter` interfaces.
* Reorders the output spreadsheet columns to match with the final tracking sheet, so that I have to do less work to copy detections between the sheets.

This patchset is easiest to review by just viewing the final file, since most of the lines have been modified.

Note that I/we intend to replace this script entirely with a new implementation that uses the newer JSON format for OE CVE reports. So these changes are somewhat temporary.

# Testing
* [x] Used this scripting to perform the iteration 11 CVE audit.
* Otherwise, this is developer-only.