### PR TITLE
diff-cve-csvs.py: set sane verbosity default

### DIFF
--- a/scripts/dev/diff-cve-csvs.py
+++ b/scripts/dev/diff-cve-csvs.py
@@ -62,7 +62,7 @@ def main(argv=sys.argv[1:]):
     parser = argparse.ArgumentParser(description="Parse the CVEs in the given csv files and generate diff information")
     parser.add_argument("old_csv", type=Path, help="Path to the older csv file.")
     parser.add_argument("new_csv", type=Path, help="Path to the newer csv file")
-    parser.add_argument("-v", "--verbose", action="count")
+    parser.add_argument("-v", "--verbose", action="count", default=0)
 
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
The argparse module sets the default value of a 'count' action argument to NoneType, instead of zero. This causes the script to throw a comparison error when later evaluating the verbosity level, in cases where the user hasn't given the '-v' argument.

Set the default to `0`, so that comparison works as expected.

```
[0] usr0:24.0.0d89$ python3 ~/fast/nilrt-kirkstone/scripts/dev/diff-cve-csvs.py ../24.0.0d70/cve_summary.csv ./cve_summary.csv 
Traceback (most recent call last):
  File "/home/usr0/fast/nilrt-kirkstone/scripts/dev/diff-cve-csvs.py", line 91, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/usr0/fast/nilrt-kirkstone/scripts/dev/diff-cve-csvs.py", line 69, in main
    if args.verbose >= 2:
       ^^^^^^^^^^^^^^^^^
TypeError: '>=' not supported between instances of 'NoneType' and 'int'
```

# Testing
* [x] Script now works without the `-v` arg.

# Control
* Will cherry-pick into the new `nilrt/master/next` ref.