### PR TITLE
Update sync_issues_to_azdo.yml to match AzDO area path update

### DIFF
--- a/.github/workflows/sync_issues_to_azdo.yml
+++ b/.github/workflows/sync_issues_to_azdo.yml
@@ -15,7 +15,7 @@ jobs:
           github_token: "${{ secrets.GH_REPO_TOKEN }}"
           ado_organization: "ni"
           ado_project: "DevCentral"
-          ado_area_path: "DevCentral\\Product RnD\\PlatformSW\\Platform HW and Drivers\\Drivers\\RTOS"
+          ado_area_path: "DevCentral\\Product RnD\\Platform HW and SW\\Core SW and Drivers\\Platform HW and Drivers\\Drivers\\RTOS"
           ado_wit: "Bug"
           ado_new_state: "Defined"
           ado_active_state: "Active"


### PR DESCRIPTION
The RTOS area path in Azure DevOps has been moved, so reflect that change in where Bugs for GitHub Issues area created.

@ni/rtos 