### PR TITLE
[kirkstone] README.kernel.md: add libncurses to host deps

### DIFF
--- a/docs/README.kernel.md
+++ b/docs/README.kernel.md
@@ -75,6 +75,7 @@ apt-get update && apt-get install -y \
 	kmod \
 	libelf-dev \
 	libssl-dev \
+	libncurses-dev \
 	make \
 	u-boot-tools \
 ""


### PR DESCRIPTION
The libncurses-dev package is necessary to `make menuconfig` later in the README. So add it to the required host dependencies.

[AB#2578764](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2578764)

# Testing
* [x] After installing this requirement to a debian:12 container, it can now `make menuconfig`.

# Meta
* WIll cherry-pick to the `nilrt/24.3/kirkstone` release branch.