### PR TITLE
qemu: Update qemu cpu to correct model

### DIFF
--- a/scripts/pipelines/build.vms.sh
+++ b/scripts/pipelines/build.vms.sh
@@ -150,7 +150,7 @@ build_qemu_vm() {
 
 	echo "Provisioning NILRT on QEMU VM..."
 	$PYREX_RUN qemu-system-x86_64 \
-		${enableKVM:-} -cpu qemu64 -smp cpus=1 \
+		${enableKVM:-} -cpu Nehalem,check=false -smp cpus=1 \
 		-m "$memory_mb" \
 		-nographic \
 		-drive if=pflash,format=raw,readonly=on,file="./OVMF/OVMF_CODE.fd" \

--- a/scripts/pipelines/vm-resources/runQemuVM.sh
+++ b/scripts/pipelines/vm-resources/runQemuVM.sh
@@ -108,7 +108,7 @@ fi
 SCRIPT_DIR="`dirname "$BASH_SOURCE[0]"`"
 set -x
 qemu-system-x86_64 \
-	${enableKVM:-} -cpu qemu64 -smp cpus=${cpu_count:-1} -machine vmport=off \
+	${enableKVM:-} -cpu Nehalem,check=false -smp cpus=${cpu_count:-1} -machine vmport=off \
 	-m "${mem_mbs:-${VM_MEM_SIZE_MB}}" \
 	-drive if=pflash,format=raw,readonly,file="$SCRIPT_DIR/OVMF/OVMF_CODE.fd" \
 	-drive if=pflash,format=raw,file="$SCRIPT_DIR/OVMF/OVMF_VARS.fd" \


### PR DESCRIPTION
nilrt uses "core2-64" tuning which supports SSSE3 instructions; so programs may be compiled with those instructions.

However, "qemu64" cpu model does not support these instructions which can cause "Illegal instruction" crashes.

Update cpu model to "Nehalem" and set "check=false" like upstream has done in tune-core2.inc.

WI: [AB#2692662](https://dev.azure.com/ni/DevCentral/_workitems/edit/2692662)

### Testing
- [x] Ran the scripts with and without kvm enabled and verified provisioning, booting works.

### Note
This issue exists in kirkstone as well (`opkg install` crashes on PABSD instruction in `libsolver.so`), but it appears that the use of these instructions was sporadic enough that provisioning workflow wasn't affected.

Due to newer compiler stack, programs probably end up using more of these instructions on dist-next thereby affecting provisioning workflow.

Needs to be cherry-picked into `nilrt/master/kirkstone` as well.