### PR TITLE
build.core-feeds.sh: Update to build Kernel

### DIFF
--- a/scripts/pipelines/build.core-feeds.sh
+++ b/scripts/pipelines/build.core-feeds.sh
@@ -7,3 +7,6 @@ SCRIPT_ROOT=$(realpath $(dirname $BASH_SOURCE))
 echo "INFO: Building the core package feed."
 bitbake packagefeed-ni-core
 bitbake package-index
+
+# AB#2791248: Build the Linux Kernel to ensure CVEs are made available
+bitbake linux-nilrt


### PR DESCRIPTION
Update build.core-feeds.sh script to additionally build Linux Kernel in order to generate CVE