### PR TITLE
repos.conf: Updated upstream sources for scarthgap

### DIFF
--- a/scripts/dev/upstream_merge/repos.conf
+++ b/scripts/dev/upstream_merge/repos.conf
@@ -5,9 +5,9 @@ sources/meta-openembedded    https://git.openembedded.org/meta-openembedded     
 sources/meta-selinux         https://git.yoctoproject.org/meta-selinux             scarthgap             nilrt/master/next
 sources/openembedded-core    https://git.openembedded.org/openembedded-core        scarthgap             nilrt/master/next
 sources/meta-virtualization  https://git.yoctoproject.org/meta-virtualization      scarthgap             nilrt/master/next
-sources/meta-security        https://git.yoctoproject.org/meta-security            master                nilrt/master/next
+sources/meta-security        https://git.yoctoproject.org/meta-security            scarthgap             nilrt/master/next
 sources/meta-sdr             https://github.com/balister/meta-sdr                  master                nilrt/master/next
-sources/meta-qt5             https://github.com/meta-qt5/meta-qt5                  master                nilrt/master/next
+sources/meta-qt5             https://github.com/meta-qt5/meta-qt5                  scarthgap             nilrt/master/next
 sources/meta-qt5-extra       https://github.com/schnitzeltony/meta-qt5-extra       master                nilrt/master/next
 sources/meta-rauc            https://github.com/rauc/meta-rauc                     scarthgap             nilrt/master/next
 sources/pyrex                https://github.com/garmin/pyrex                       master                nilrt/master/next


### PR DESCRIPTION
More repos now have scarthgap branches so update those.

[AB#2755018](https://dev.azure.com/ni/DevCentral/_workitems/edit/2755018)