### PR TITLE
Update build-nilrt.Dockerfile to enable Talladega to use the exported docker images

### DIFF
--- a/docker/build-nilrt.Dockerfile
+++ b/docker/build-nilrt.Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update && apt-get install --assume-yes \
 	genisoimage \
 	qemu-system-x86 \
 	qemu-utils \
+	libtinfo5 \
+	openssh-client \
 ""
 
 # this Dockerfile layer contains nothing yet.


### PR DESCRIPTION
Talladega would like to use the nilrt-built docker images in `build_nilrt_containers` to build Talladega images.  The Talladega build process requires the 2 components added in this PR to be included in the docker image our our build will fail.
