### PR TITLE
README: Workaround for old libseccomp failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
 
     If you are building on a virtual machine and do not have nested virtualization enabled on the host, you will need to locally remove the `--device /dev/kvm` entry in the args assignment in the top-level pyrex.ini file.
 
+    If you are building on a host with an older version of libseccomp, you may need to add `--security-opt seccomp=unconfined` entry in the args assignment in the top-level pyrex.ini file to work around build errors, as described [here](https://github.com/moby/moby/issues/43595).
+
     **NI builders** who are connected to the NI corporate network should specify `-org` in their init script args, to provoke the script into adding the `ni-org.conf` snippet to your bitbake directory. External builders *should not* use `--org`.
 
    If you are building on a `nilrt/master/*` branch ref (rather than a release branch) **and** if you are building outside of the NI corporate network, you will need to set the version of the `ni-main` opkg feed to one which has already been published to `download.ni.com`. Do this by setting the `NILRT_MAIN_FEED_VERSION` bitbake variable to the latest published release. eg.


### PR DESCRIPTION
On build hosts containing old libseccomp versions, builds can fail with "Failed to close file descriptor for child process (Operation not permitted)" error.

Document workaround for this.

WI: [AB#2755029](https://dev.azure.com/ni/DevCentral/_workitems/edit/2755029)

### Testing
- [x] Formatting looks good in GitHub UI.

### Note
Needs to be cherry picked into `nilrt/24.8/kirkstone` and `nilrt/master/next`.