### PR TITLE
cve-to-csv.py: Handle new fields in the CVE files

### DIFF
--- a/scripts/pipelines/cve-to-csv.py
+++ b/scripts/pipelines/cve-to-csv.py
@@ -24,9 +24,12 @@ class CVE():
         'CVE': 'id',
         'CVE STATUS': 'status',
         'CVE SUMMARY': 'summary',
+        'CVE DETAIL': 'detail',
+        'CVE DESCRIPTION': 'description',
         'CVSS v2 BASE SCORE': 'score_v2',
         'CVSS v3 BASE SCORE': 'score_v3',
         'VECTOR': 'vector',
+        'VECTORSTRING': 'vector_string',
         'MORE INFORMATION': 'more_information',
     }
 


### PR DESCRIPTION
In order to support arbitrary multi-line field values, the parsing code looks for any known field name to terminate each value. Some new fields have been added, which were breaking the parsing code.

Noticed this when doing a CVE check.

**Testing:**
Ran the script against an old set of CVE files (before the new fields were present) both with and without these changes and confirmed the output was the same. Ran the script against a new set of CVE files (with the new fields) and did a spot check to confirm this fixed the parsing issues I was seeing.