### PR TITLE
cve-to-csv.py: Handle new score_v4 field in CVE files

### DIFF
--- a/scripts/pipelines/cve-to-csv.py
+++ b/scripts/pipelines/cve-to-csv.py
@@ -28,6 +28,7 @@ class CVE():
         'CVE DESCRIPTION': 'description',
         'CVSS v2 BASE SCORE': 'score_v2',
         'CVSS v3 BASE SCORE': 'score_v3',
+        'CVSS v4 BASE SCORE': 'score_v4',
         'VECTOR': 'vector',
         'VECTORSTRING': 'vector_string',
         'MORE INFORMATION': 'more_information',


### PR DESCRIPTION
In order to support arbitrary multi-line field values, the parsing code looks for any known field name to terminate each value. A new field was added, which is breaking the parsing code.

Noticed this when doing a CVE check.

**Testing:**
Ran the script against an old set of CVE files (before the new field was present) and a new set of CVE files (with the new field) and confirmed the parsing issue was fixed and the output looked sane.