### PR TITLE
create-build-nilrt: Set PYREX_BASE to ubuntu 24.04

### DIFF
--- a/docker/build-nilrt.Dockerfile
+++ b/docker/build-nilrt.Dockerfile
@@ -6,6 +6,6 @@ RUN apt-get update && apt-get install --assume-yes \
 	genisoimage \
 	qemu-system-x86 \
 	qemu-utils \
-	libtinfo5 \
+	libtinfo6 \
 	openssh-client \
 ""

--- a/docker/create-build-nilrt.sh
+++ b/docker/create-build-nilrt.sh
@@ -3,7 +3,7 @@ set -u
 
 SCRIPT_ROOT=$(realpath $(dirname ${BASH_SOURCE}))
 PYREX_ROOT=$(realpath "${SCRIPT_ROOT}/../sources/pyrex")
-PYREX_BASE=ubuntu-22.04-oe
+PYREX_BASE=ubuntu-24.04-oe
 
 IMAGE_NAME=build-nilrt
 


### PR DESCRIPTION
Set PYREX_BASE to ubuntu-24.04-oe to be able to build 6.12 kernel.

Also update build-nilrt.Dockerfile to use libtinfo6 instead of libtinfo5.

These changes are required to be able to build 6.12 kernel.

WI: [AB#2951013](https://dev.azure.com/ni/DevCentral/_workitems/edit/2951013)

### Testing
- [x] Built docker image locally
- [x] Built `packagefeed-ni-core`, `nilrt-base-system-image`, `packagegroup-ni-next-kernel`


### Note

Was seeing following error without these changes

`gcc: error: unrecognized command-line option '-fcanon-prefix-map'; did you mean '-fmacro-prefix-map='?` 

We're using gcc 13.3 in scarthgap which has support for that option.
But pyrex container was using using ubuntu 22.04 which has gcc version 11.4.0 and doesn't support that option.

I'd have expected kernel to be built with OE built toolchain but seems to not be happening. WI: [AB#3068018](https://dev.azure.com/ni/DevCentral/_workitems/edit/3068018) to look into this.