### PR TITLE
test pr please ignore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# For safety, the CODEOWNERS file shoudld be protected by the primary maintainers directly.
+/.github/CODEOWNERS  @amstewart @chaitu236
+
+# By default, the maintainers group should be a reviewer on all PRs.
+*  @ni/openembedded-maintainers


### PR DESCRIPTION
To assist PR creators in adding the correct owners to their PRs, add a CODEOWNERS file and configure it to add the NILRT maintainers to all PRs.