### PR TITLE
Add a CODEOWNERs and PR template file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# By default, the maintainers group should be a reviewer on all PRs.
+*  @ni/openembedded-maintainers
+
+# For safety, the CODEOWNERS file should be protected by the primary maintainers directly.
+# Always keep this line at the bottom of the file, for rule parsing.
+/.github/CODEOWNERS  @amstewart @chaitu236

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# Changes
+
+*TODO: Summary of changes in this PR.*
+
+
+# Testing
+
+*TODO: How were the changes in this PR tested?*
+
+
+# Process
+
+*TODO: Check boxes that apply to this PR and are complete. Remove boxes that do not apply.*
+
+* [ ] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.
+
+
+__Suggested Reviewers:__
+* @ni/rtos


### PR DESCRIPTION
# Changes

1. Add a CODEOWNERS file that will automatically add the repo maintainers team to PRs, unless there is a more specific owner.
2. Add a PR template which asks for basic information. It will also at-mention the RTOS team for review.


# Testing

* [x] Pushed a dev branch with these controls in place and verified that...
  * modifying a repo file would automatically add the maintainers group to the PR.
  * modifying the CODEOWNERS file itself would add chaitanya and/or me to the PR.
* [x] When a PR was opened against my default branch, it was populated with the new PR template.


# Process

* [x] This PR should be cherry-picked to the next/ ref.

@ni/rtos 