### PR TITLE
cve-to-csv-v2: Create script using json exports

### DIFF
--- a/scripts/pipelines/cve-to-csv-v2.py
+++ b/scripts/pipelines/cve-to-csv-v2.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+from pathlib import Path
+import json
+import os
+import sys
+
+
+parser = ArgumentParser(
+    description="Parses a directory full of OE cve_check json files, and writes their csv equivalent to stdout.",
+    )
+parser.add_argument('cve_directory', type=Path,
+    help='Path to the cve_check output directory.'
+    )
+args = parser.parse_args()
+
+
+class CVE():
+
+    JSON_ISSUE_FIELD = 'issue'
+    JSON_PACKAGE_FIELD = 'package'
+    JSON_PRODUCT_FIELD = 'products'
+
+
+    JSON_PACKAGE_SEC_FIELDS = {
+        'layer': 'layer',
+        'name': 'package_name',
+        'version': 'package_version'
+    }
+
+
+    JSON_ISSUE_SEC_FIELDS = {
+        'id': 'id',
+        'status': 'status',
+        'summary': 'summary',
+        'detail': 'detail',
+        'description': 'decription',
+        'scorev2': 'score_v2',
+        'scorev3': 'score_v3',
+        'scorev4': 'score_v4',
+        'vector': 'vector',
+        'vector_string': 'vector_string',
+        'link': 'more_information'
+    }
+
+
+    CVE_HEADER = \
+        list(JSON_PACKAGE_SEC_FIELDS.values()) + \
+        list(JSON_ISSUE_SEC_FIELDS.values())
+
+
+    def __init__(self):
+        pass
+
+
+    @staticmethod
+    def get_cves(package):
+        package_info = ''
+        for field in list(CVE.JSON_PACKAGE_SEC_FIELDS.keys()):
+            package_info += package.get(field) + ','
+
+        package_issues = package.get(CVE.JSON_ISSUE_FIELD)
+        cve_list = []
+        for issue in package_issues:
+            cve = package_info
+            for field in list(CVE.JSON_ISSUE_SEC_FIELDS.keys()):
+                cve += '"' + issue.get(field, 'N/A').replace('"', '\'') + '"' + ','
+            cve += '\n'
+
+            cve_list.append(cve)
+
+        return cve_list
+
+
+cves = []
+for root, dirs, fils in os.walk(args.cve_directory):
+    for fil in fils:
+        if fil.startswith('.') or not fil.endswith('.json'):
+            continue # skip hidden files and non-json files
+        sys.stderr.write(f'Processing CVE file: {fil}\n')
+        cve_file = os.path.join(root, fil)
+        with open(cve_file, 'r') as fp_cve:
+            package_cves = json.load(fp_cve)
+            new_cve = CVE.get_cves(package_cves.get(CVE.JSON_PACKAGE_FIELD)[0])
+            if new_cve:
+                cves.extend(new_cve)
+        sys.stderr.write('\n')
+
+sys.stdout.write(','.join(CVE.CVE_HEADER) + '\n')
+for cve in cves:
+    sys.stdout.write(cve)


### PR DESCRIPTION
# POC: Not intended for submission

# Changes

Created `cve-to-csv-v2.py` to use json export files to generate CVE Summary


# Testing

Tested script against `rtos_oe_feeds 25.5d81` oe-core cve folder
  - Validated generated `cve_summary.csv` against exported `cve_summary.csv`
    - Equivalent number of CVEs generated


# Process

* [ ] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.


__Suggested Reviewers:__
* @ni/rtos
