### PR TITLE
CHANGELOG: Update for 25.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,33 @@ This changelog attempts to conform to the changelog spec on [keepachangelog.org]
 The evergreen, canonical changelog for *all NILRT branches* can be [found here](https://github.com/ni/nilrt/blob/HEAD/CHANGELOG.md).
 
 ## Latest Updates
-* nilrt: 301
-* meta-nilrt: 812
-* linux: 215
+* nilrt: 307
+* meta-nilrt: 852
+* linux: 235
+
+
+----
+## 11.2
+Branch: `nilrt/25.5/scarthgap`
+
+### nilrt
+No changes.
+
+### meta-nilrt
+
+
+#### Added
+- [Added](https://github.com/ni/meta-nilrt/pull/835) support for wired `802.1X`.
+- [Added](https://github.com/ni/meta-nilrt/pull/839) `/var/log`, `/var/local/natinst/log`, `/var/lib/pstore` to Hardware Configuration Utility Technical Support Report.
+- [Added](https://github.com/ni/meta-nilrt/pull/842) nilrt container images.
+- [Added](https://github.com/ni/meta-nilrt/pull/852) scripts to support tracing from LabVIEW.
+
+#### Changed
+- [Upgraded](https://github.com/ni/meta-nilrt/pull/821) `linux-nilrt-next` to `6.12`.
+- [Enabled](https://github.com/ni/meta-nilrt/pull/840) persistent logging by default.
+
+#### Fixed
+- [Fixed](https://github.com/ni/meta-nilrt/pull/833) coreutils package priority value.
 
 
 ----
@@ -393,6 +417,12 @@ Branch: `nilrt/22.5/hardknott`
 - [Removed](https://github.com/ni/meta-nilrt/pull/355) boot attestation based on now dead upstream code.
 - [Removed](https://github.com/ni/meta-nilrt/pull/290) packages dropped from upstream.
 
+
+----
+## 8.24
+Branch: `nilrt/25.5/sumo`
+
+No changes.
 
 ----
 ## 8.23


### PR DESCRIPTION
Updated the CHANGELOG for the 25.5 scarthgap release.
[AB#3039693](https://dev.azure.com/ni/DevCentral/_workitems/edit/3039693/)