### PR TITLE
Automating upstream merge and testing

### DIFF
--- a/scripts/dev/upstream_merge/README.md
+++ b/scripts/dev/upstream_merge/README.md
@@ -1,0 +1,229 @@
+# MOTIVATION
+
+To ensure the long-term maintainability and efficiency of the ni/nilrt repository, automating the upstream merge process is a crucial step. Manual upstream merges are often tedious, time-consuming, and prone to human error, especially as the size and frequency of upstream changes grow. By automating this process, we can significantly reduce the cost of maintenance by saving several hours of manual effort per release cycle. This allows developers to focus more on value-adding tasks rather than routine integration work. Automation also ensures that our fork stays closely aligned with upstream changes, minimizing future integration conflicts and making it easier to adopt new features, security patches, and bug fixes promptly. Overall, this improves the quality, stability, and security of the codebase while enhancing the team's productivity and responsiveness to upstream evolution.
+
+The script does the following tasks:
+- Automatically merges changes from upstream repositories into the local fork, reducing manual effort.
+- Builds the safemode and runmode images after a successful merge to ensure the codebase is functional.
+- Installs and tests these images on a RT target via SSH to verify that the integration is successful and the target works as expected.
+- Commits and pushes the new changes and creates a PR targeting the main branch.
+- Sends email reports about the merge and build status.
+
+Overall, it streamlines and safeguards the process of keeping the local fork up-to-date with upstream changes, ensuring quality and reducing maintenance overhead.
+
+---
+
+## **Script Overview**
+
+### **Workflow for Each Submodule in the `nilrt` Repository**
+
+1. **Check Out the Base Branch**:
+   - The script checks out the base branch as specified in the [`repos.conf`](./repos.conf) file.
+
+2. **Pull the Upstream Branch**:
+   - The upstream branch mentioned in [`repos.conf`](./repos.conf) is pulled to ensure the latest changes are fetched.
+
+3. **Merge the Two Branches**:
+   - The base branch and the upstream branch are merged.
+   - The script reports whether the merge was successful or if it encountered any conflicts.
+
+4. **Build Images on Successful Merge**:
+   - If the merge is successful, the script proceeds to build the following images:
+     - **Safemode Image**
+     - **Runmode Image**
+
+5. **Install Images on the RT Target**:
+   - The safemode and runmode images are installed on a RT target via SSH.
+   - The script then verifies the installation by running tests on the RT target (such as checking the OS version ).
+
+6. **Push Changes and Create Pull Requests**:
+   - If the build and test steps succeed, the script commits and pushes the new changes to the downstream fork repository and automatically creates a PR targeting the main branch.
+
+---
+
+## **Configuration File: `automation_conf.json`**
+
+The script is user configurable and uses `automation_conf.json` to define various parameters. **All fields are required**, and if a field is not present, `None` will be used as the default value. Below is an explanation of the fields in the configuration file:
+
+- **`nilrt_branch`**:
+  The nilrt branch to pull the latest changes from.
+
+- **`meta_nilrt_branch`**:
+  The meta-nilrt branch to pull the latest changes from.
+
+- **`conf_file_path`**:
+  Path to the configuration file (default: [`repos.conf`](./repos.conf)).
+
+- **`force_checkout`**:
+  Enables forceful checkout to the base branch if set to `True`.
+
+- **`upstream_repo_name`**:
+  The name of the upstream remote repository.
+
+- **`merge_branch_name`**:
+  The name of the branch where the merge will be performed.
+
+- **`username`**:
+  GitHub username where the forks are maintained.
+
+- **`fork_name`**:
+  The name of the downstream fork repository where the merge will be performed. This is the repository owned by the user specified in the username field.
+
+- **`email_from`**:
+  The email address from which the merge report will be sent.
+
+- **`email_to`**:
+  The email address to which the merge report will be sent.
+
+- **`email_log_level`**:
+  - **`0`**:
+    - Includes the status of the upstream merge:
+      - **`... OK`**: Merge completed successfully.
+      - **`... OK (no changes)`**: No changes were detected during the merge.
+      - **`... ERRORS`**: Errors occurred during the merge.
+    - In case of a merge conflict, the error details will also be included in the email.
+
+  - **`1`**:
+    - Includes the diff (differences) for a successful merge in addition to the status.
+
+- **`log_level`**:
+  Integer representing the logging level:
+  - `10`: DEBUG
+  - `20`: INFO
+  - `30`: WARNING
+  - `40`: ERROR
+  - `50`: CRITICAL
+
+- **`build_args`**:
+  String of extra arguments to pass to the build process (e.g., `"--org"` for NI corporate network builds).
+
+- **`rt_target_IP`**:
+  The IP address or hostname of the RT target where images will be installed and tested via SSH.
+
+**`Note`**:
+- If the configuration file is `automation_conf.json`, you do not need to specify its path explicitly, as it is set as default. However, if you are using a different configuration file, you must provide its path using the `-c` argument.
+For example:
+
+```bash
+python3 scripts/dev/upstream_merge/upstream_merge_and_test.py -c path/to/your_config.json -w workItemID
+```
+
+
+---
+
+# HOW TO USE THE MERGE SCRIPT
+
+### **1. Navigate to the root of the nilrt repo**
+```bash
+cd ~/nilrt
+```
+
+### **2. Run the Script**
+#### **To Perform a Merge**
+This will merge upstream changes, build the images, test them on the RT target, and create PRs with the new changes after the build and test steps succeed.
+
+Note that these steps are serial. The build should succeed for the test to run, and the test should pass for the PRs to be created.
+
+```bash
+python3 scripts/dev/upstream_merge/upstream_merge_and_test.py -c path/to/your_config.json -w workItemID
+```
+
+- **`workItemID`**:
+The `workItemID` associated with the pull request.
+
+
+#### **To Skip the Merge and Only Build, Test, and Create PRs**
+
+Enable this option when a merge conflict has occurred and you have resolved it manually.
+This option is used to skip the automated upstream merge step in the pipeline, allowing the build and test stages to proceed with your manually resolved state.
+
+**How to Manually Resolve a Merge Conflict:**
+
+Once you have resolved the conflict and committed the changes on the build machine, you can rerun the script with the `-s` option to skip the automated merge and proceed directly to the build and test stages.
+
+```bash
+python3 scripts/dev/upstream_merge/upstream_merge_and_test.py -c path/to/your_config.json -w workItemID -s
+```
+#### **To Skip Pushing the Changes and Creating PRs**
+
+Enable this option if you want to run the merge, build, and test steps, but do **not** want to push any changes or create pull requests. This can be useful for dry runs, debugging, or when you want to verify the process without affecting the remote repository.
+
+To use this option, pass the `-skip_push_and_pr` flag when running the script:
+
+```bash
+python3 scripts/dev/upstream_merge/upstream_merge_and_test.py -c path/to/your_config.json -w workItemID -skip_push_and_pr
+```
+
+---
+
+## **Supporting Files**
+
+### **`shell_commands.py`**
+- Provides utility functions to execute shell commands.
+- Acts as a wrapper for running system commands from Python.
+
+### **`git_commands.py`**
+- Contains various Git-related functions that rely on `shell_commands.py`.
+- Includes operations like fetching, pulling, creating branches, and merging.
+
+### **`git_repo.py`**
+- Defines the `git_repo` class, which encapsulates details and operations for a Git repository.
+-  Data members are:
+    - local_repo
+    - local_base_branch
+    - upstream_branch
+    - upstream_repo_name
+    - upstream_repo_url
+    - fork_name
+    - fork_url
+
+### **`upstream_merge.py`**
+- Contains helper functions for merging submodules with their respective upstream repositories.
+
+### **`build.py`**
+- Handles the process of building images.
+- Key steps include:
+  - Setting up the Docker environment.
+  - Building core feeds.
+  - Building core images.
+
+### **`test.py`**
+- Manages testing of the built images on an RT target via SSH.
+- Key steps include:
+  - Installing and testing safemode and runmode images.
+  - Verifying the OS version.
+
+### **`push_branch_and_create_pr.py`**
+- Handles pushing the merged changes to the downstream fork repository.
+- Automates the creation of a pull request on GitHub after a successful merge and build.
+- Uses the GitHub CLI or API to generate PRs with appropriate titles, descriptions, and checklists.
+
+> **Important Note:**
+> The `push_branch_and_create_pr.py` script performs a **force push** (`git push --force`) to the downstream fork repository.
+> This will overwrite the remote branch history and may cause loss of commits if others have pushed to the same branch.
+> Use with caution and ensure you coordinate with your team before running this script.
+
+### **`json_config.py`**
+- Handles reading and validating the configuration file.
+- Key responsibilities include:
+  - Parsing the JSON configuration file.
+  - Validating required fields and their values.
+  - Providing easy access to configuration parameters for other scripts.
+
+### **`log_and_email_utils.py`**
+- Provides utilities for logging, formatting merge/build/test reports, and sending email notifications.
+- Used by automation scripts to set up logging, format status reports, and send summary emails after merges, builds, and tests.
+
+---
+
+## Contact
+
+If you have any questions or need assistance, feel free to contact:
+
+- Name: Shreejit C
+  - GitHub Username: Shreejit-03
+  - Email: shreejit.c@emerson.com
+
+- Name: Pratheeksha S N
+  - GitHub Username: pratheekshasn
+  - Email: pratheeksha.s.n@emerson.com

--- a/scripts/dev/upstream_merge/automation_conf.json
+++ b/scripts/dev/upstream_merge/automation_conf.json
@@ -1,0 +1,16 @@
+{
+    "nilrt_branch":"nilrt/master/scarthgap",
+    "meta_nilrt_branch":"nilrt/master/scarthgap",
+    "conf_file_path": "scripts/dev/upstream_merge/repos.conf",
+    "force_checkout": false,
+    "upstream_repo_name": "automerge_upstream",
+    "merge_branch_name": "dev/automerge/ni",
+    "fork_name": "myfork",
+    "email_log_level": 1,
+    "log_level": 10,
+    "email_from": "shreejit.c@emerson.com",
+    "email_to": "pratheeksha.s.n@emerson.com",
+    "username": "",
+    "build_args":"",
+    "rt_target_IP":""
+}

--- a/scripts/dev/upstream_merge/json_config.py
+++ b/scripts/dev/upstream_merge/json_config.py
@@ -1,0 +1,29 @@
+"""Provides utilities for reading and validating the automation_conf.json
+    configuration file."""
+
+import json
+import os
+
+
+class JsonConfig:
+    """Handles loading and validating the automation_conf.json
+        configuration file."""
+
+    def __init__(self, automation_conf_path, work_item_id):
+        with open(automation_conf_path, "r", encoding="utf-8") as file:
+            config = json.load(file)
+        self.work_item_id = work_item_id
+        self.nilrt_branch = config.get("nilrt_branch")
+        self.meta_nilrt_branch = config.get("meta_nilrt_branch")
+        self.conf_file_path = os.getcwd() + f"/{config.get('conf_file_path')}"
+        self.force_checkout = config.get("force_checkout")
+        self.upstream_repo_name = config.get("upstream_repo_name")
+        self.merge_branch_name = config.get("merge_branch_name")
+        self.username = config.get("username")
+        self.fork_name = config.get("fork_name")
+        self.email_from = config.get("email_from")
+        self.email_to = config.get("email_to")
+        self.email_log_level = config.get("email_log_level")
+        self.log_level = config.get("log_level")
+        self.build_args = config.get("build_args", "")
+        self.rt_target_IP = config.get("rt_target_IP")

--- a/scripts/dev/upstream_merge/log_and_email_utils.py
+++ b/scripts/dev/upstream_merge/log_and_email_utils.py
@@ -1,0 +1,194 @@
+"""
+Utilities for logging, formatting merge reports, and sending email
+notifications.
+"""
+
+import os
+import datetime
+import logging
+from utils.git_commands import send_email
+
+
+def setup_logging(log_level=10):
+    """
+    Set up logging configuration.
+    :param log_level: Logging level (default: 10).
+    """
+    global LOG_DIR
+    LOG_DIR = f"temp/{datetime.datetime.now().strftime('%d-%m-%Y')}"
+    os.makedirs(LOG_DIR, exist_ok=True)
+    log_file = (
+        f"{LOG_DIR}/upstream_merge_"
+        f"{datetime.datetime.now().strftime('%H-%M-%S')}.log"
+    )
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.FileHandler(log_file, mode="a")],
+    )
+
+
+def write_email_headers(email_file_name, email_from,  email_to):
+    """
+    Write email header information to a log file.
+
+    :param email_file_name: The name of the log file to write to.
+    :param email_from: The sender's email address.
+    :param email_to: The recipient's email address.
+    """
+    with open(email_file_name, "w", encoding="utf-8") as log:
+        log.write(f"From: {email_from}\n")
+        log.write(f"To: {email_to}\n")
+        log.write("Subject: Merge Details\n\n")
+
+
+def format_status(status, message):
+    """
+    Format the status and message for display/logging.
+
+    :param status: Status code (0 for success, non-zero for errors).
+    :param message: Associated message or details.
+    :return: Tuple of formatted status strings for summary and detailed logs.
+    """
+    error_msg = f" ... ERRORS\n    {message or ''}\n\n\n"
+    ok_no_changes = " ... OK (no changes)"
+    ok_msg = f" ... OK\n    {message}\n\n\n"
+
+    if status != 0:
+        return (" ... ERRORS", error_msg)
+
+    if message is None:
+        return (ok_no_changes, f"{ok_no_changes}\n\n\n")
+
+    return (" ... OK", ok_msg)
+
+
+def format_merge_report(merge_report, email_log_level, skip_push_and_pr=False):
+    """
+    Format the merge report for email or logging.
+
+    The formatted report string is structured as follows:
+    - The first line contains the repository name.
+    - The second line contains the status of the merge (OK, ERRORS, or no
+      changes).
+    - The diff is added if there are any changes and if email_log_level is set
+      to 1.
+
+    Merge completed successfully:
+    sources/bitbake
+     ... OK
+         Push and PR ... OK
+
+    No changes were detected during the merge:
+    sources/bitbake
+     ... OK (no changes)
+
+    Errors occurred during the merge:
+    sources/bitbake
+     ... ERRORS
+    """
+    min_detail = ""
+    error_detail = ""
+    diff_detail = ""
+
+    build_and_test_detail = merge_report.pop("Build and Test")
+    if build_and_test_detail[0] == 0 and not skip_push_and_pr:
+        push_and_pr_details = merge_report.pop("Push and PR")
+    # Remove the build/test and PR results from the merge report so that
+    # the subsequent loop can focus solely on per-repository merge outcomes.
+    # This streamlines the logic and ensures only relevant entries are
+    # processed.
+
+    for git_obj, (status, message) in merge_report.items():
+        min_line, additional_line = format_status(status, message)
+
+        layer_name = git_obj.local_repo.split("/")[-1]
+        min_detail += f"{layer_name}\n{min_line}\n"
+
+        if status != 0:
+            error_detail += f"{layer_name}\n{message}\n"
+
+        diff_detail += f"{layer_name}\n{additional_line}"
+
+        if (
+            build_and_test_detail[0] == 0
+            and not skip_push_and_pr
+            and status == 0
+            and message is not None
+        ):
+            git_obj_push_details = push_and_pr_details[git_obj]
+            if git_obj_push_details[0] == 0:
+                min_detail += "     Push and PR ... OK\n"
+                diff_detail += "     Push and PR ... OK\n"
+            else:
+                min_detail += "     Push and PR ... ERRORS\n"
+                error_detail += (
+                    f"{git_obj.local_repo}\n{min_line}\n"
+                    f"     Push and PR ... ERRORS\n"
+                    f"    {git_obj_push_details[1]}\n"
+                )
+                diff_detail += (
+                    "     Push and PR ... ERRORS\n"
+                    f"    {git_obj_push_details[1]}\n"
+                )
+
+    min_detail += "Build and Test\n"
+    if build_and_test_detail[0] == 0:
+        min_detail += (
+            f"\nBuild and Test\n ... OK\n    {build_and_test_detail[1]}\n"
+        )
+        diff_detail += (
+            f"\nBuild and Test\n ... OK\n    {build_and_test_detail[1]}\n"
+        )
+    else:
+        min_detail += " ... ERRORS\n"
+        error_detail += (
+            f"\nBuild and Test\n ... ERRORS\n    {build_and_test_detail[1]}\n"
+        )
+        diff_detail += (
+            f"\nBuild and Test\n ... ERRORS\n    {build_and_test_detail[1]}\n"
+        )
+
+    if email_log_level == 0:
+        return min_detail + "\n\n" + error_detail
+    return min_detail + "\n\n" + error_detail + "\n\n" + diff_detail
+
+
+def write_log(email_file_name, contents):
+    """
+    Append the given contents to the specified log file.
+
+    :param email_file_name: The name of the log file to write to.
+    :param contents: The string content to append to the log file.
+    """
+    with open(email_file_name, "a", encoding="utf-8") as log:
+        log.write(contents)
+
+
+def write_log_and_send_email(
+    email_from, email_to, merge_report, email_log_level, skip_push_and_pr=False
+):
+    """
+    Write the merge report to a log file, then send it as an email.
+
+    :param email_from: The sender's email address.
+    :param email_to: The recipient's email address.
+    :param merge_report: The merge report data structure.
+    :param email_log_level: The log verbosity level for the email.
+    :param skip_push_and_pr: Flag to handle the merge report for skipping push
+        and PR creation.
+    """
+    email_file_name = (
+        LOG_DIR + "/"
+        f"upstream_merge_{datetime.datetime.now().strftime('%H-%M-%S')}.txt"
+    )
+    formatted_report_string = format_merge_report(
+        merge_report, email_log_level, skip_push_and_pr
+    )
+    write_email_headers(email_file_name, email_from, email_to)
+    write_log(email_file_name, formatted_report_string)
+    send_email(
+        to_address=email_to,
+        subject="Merge Details",
+        file=email_file_name
+    )

--- a/scripts/dev/upstream_merge/upstream_merge.py
+++ b/scripts/dev/upstream_merge/upstream_merge.py
@@ -1,0 +1,155 @@
+"""
+Workflow for automating the upstream merge process for submodules and
+repositories.
+"""
+
+
+def merge_upstream(git_obj, force_checkout, merge_branch_name):
+    """
+    Merge the latest changes from the upstream branch.
+
+    :param git_obj: The GitRepo object to interact with the repository.
+    :param force_checkout: Boolean indicating whether to force checkout to
+        the base branch.
+    :param merge_branch_name: The name of the merge branch to use.
+    :return: A tuple (status_code, message). Returns (0, None) if no changes or
+        (0, diff) if merged.
+    """
+    merge_prepare_details = prepare_for_merge(git_obj, force_checkout)
+    if merge_prepare_details[0] != 0:
+        return merge_prepare_details
+
+    repo_details = create_merge_branch(git_obj, merge_branch_name)
+    if repo_details[0] != 0:
+        return repo_details
+
+    commit_before_merge = git_obj.get_current_commit()
+
+    merge_result = git_obj.merge_branch(
+        f"{git_obj.upstream_repo_name}/{git_obj.upstream_branch}",
+        "Merge latest upstream",
+    )
+
+    if merge_result[0] == 0:
+        diff_output = git_obj.diff()
+        if (git_obj.get_current_commit() == commit_before_merge) or \
+                diff_output == (0, "",):
+            return (0, None)  # No changes after merge [... OK (no changes)]
+        return (0, diff_output[1])  # Changes were merged successfully [... OK]
+
+    return (1, merge_result[1])  # Merge failed [... ERRORS]
+
+
+def prepare_for_merge(git_obj, force_checkout):
+    """
+    Prepare the repository for merging by switching to the base branch, pulling
+    the latest changes, fetching from upstream, and creating the merge branch.
+
+    :param git_obj: The GitRepo object to interact with the repository.
+    :param force_checkout: Boolean indicating whether to force checkout
+        the base branch.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+
+    base_branch_details = switch_to_base_branch_and_pull(
+        git_obj,
+        force_checkout
+        )
+    if base_branch_details[0] != 0:
+        return base_branch_details
+
+    fetch_details = fetch_upstream(git_obj)
+    if fetch_details[0] != 0:
+        return fetch_details
+
+    return (0, None)
+
+
+def switch_to_base_branch_and_pull(git_obj, force_checkout):
+    """
+    Switch to the base branch, optionally force checkout,
+    set the origin remote, and pull the latest changes.
+
+    :param git_obj: The GitRepo object to interact with the repository.
+    :param force_checkout: Boolean indicating whether to force checkout
+        the base branch.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    if not force_checkout:
+        branch_details = git_obj.branch_exists(git_obj.local_base_branch)
+        if not branch_details:
+            print(
+                f"\n    Branch {git_obj.local_base_branch} does not exist. "
+                "Exiting"
+            )
+            return (
+                1,
+                f"\n    Branch {git_obj.local_base_branch} does not exist. "
+                "Exiting",
+            )
+
+    checkout_details = git_obj.checkout_branch(
+        git_obj.local_base_branch, force_checkout=force_checkout
+    )
+    if checkout_details[0] != 0:
+        print(checkout_details[1])
+        return checkout_details
+
+    set_origin_details = git_obj.add_remote(
+        "origin",
+        f"https://github.com/ni/{git_obj.local_repo.split('/')[-1]}.git"
+    )
+    if set_origin_details[0] != 0:
+        print(set_origin_details[1])
+        return set_origin_details
+
+    pull_details = git_obj.pull(
+        branch_name=git_obj.local_base_branch, upstream_repo_name="origin"
+    )
+    if pull_details[0] != 0:
+        print(pull_details[1])
+        return pull_details
+
+    return (0, None)
+
+
+def fetch_upstream(git_obj):
+    """
+    Add the upstream remote and fetch the latest changes from the upstream
+    repository.
+
+    :param git_obj: The GitRepo object to interact with the repository.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    add_remote_details = git_obj.add_remote()
+    if add_remote_details[0] != 0:
+        print(add_remote_details[1])
+        return add_remote_details
+
+    fetch_details = git_obj.fetch_branch()
+    if fetch_details[0] != 0:
+        print(fetch_details[1])
+        return fetch_details
+
+    return (0, None)
+
+
+def create_merge_branch(git_obj, merge_branch_name):
+    """
+    Create and check out a new merge branch, deleting it first if it already
+    exists.
+
+    :param git_obj: The GitRepo object to interact with the repository.
+    :param merge_branch_name: The name of the merge branch to create.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    if git_obj.branch_exists(merge_branch_name):
+        git_obj.checkout_branch(git_obj.local_base_branch)
+        git_obj.delete_branch(merge_branch_name)
+
+    checkout_details = git_obj.checkout_branch(merge_branch_name, create=True)
+    if checkout_details[0] != 0:
+        print(checkout_details[1])
+        return checkout_details
+
+    return (0, None)

--- a/scripts/dev/upstream_merge/upstream_merge_and_test.py
+++ b/scripts/dev/upstream_merge/upstream_merge_and_test.py
@@ -1,0 +1,322 @@
+"""Main script for automating the upstream merge, build, test, and
+notification workflow."""
+
+import os
+import argparse
+
+from utils.test import install_and_test_image
+from json_config import JsonConfig
+from utils.git_repo import GitRepo
+from upstream_merge import merge_upstream
+from utils.push_branch_and_create_pr import push_branch_and_create_pr
+from utils.build import setup_env_and_build_packages
+from log_and_email_utils import setup_logging, write_log_and_send_email
+
+NILRT_URL = (
+    "https://github.com/ni/nilrt.git"
+)
+META_NILRT_URL = (
+    "https://github.com/ni/meta-nilrt.git"
+)
+
+
+def parse_args():
+    """
+    Parse command-line arguments for the automated repository merging script.
+
+    :return: Parsed arguments as returned by
+            argparse.ArgumentParser.parse_args().
+    """
+    parser = argparse.ArgumentParser(
+        description="Automated repository merging script"
+    )
+    parser.add_argument(
+        "-c",
+        type=str,
+        help="Path to configuration file",
+        default="scripts/dev/upstream_merge/automation_conf.json",
+    )
+    parser.add_argument(
+        "-w",
+        type=str,
+        help="Work item ID",
+        default=None,
+    )
+    parser.add_argument(
+        "-s",
+        action="store_true",
+        help="Skip merging with upstream"
+    )
+    parser.add_argument(
+        "-skip_push_and_pr",
+        action="store_true",
+        help="Skip pushing and creating PRs"
+    )
+    args = parser.parse_args()
+    return args
+
+
+def merge_submodules_with_upstream(
+    conf_file_path,
+    force_checkout,
+    username,
+    upstream_repo_name,
+    merge_branch_name,
+    fork_name,
+    skip_merge,
+):
+    """
+    Merge submodules with their respective upstream repositories
+    as defined in the repos.conf file.
+
+    :param conf_file_path: Path to the configuration file (repos.conf).
+    :param force_checkout: Boolean indicating whether to force checkout
+        to the base branch.
+    :param username: GitHub username owning the downstream fork.
+    :param upstream_repo_name: Name of the upstream remote repository.
+    :param merge_branch_name: The name of the merge branch to use.
+    :param fork_name: The name of the downstream fork repository.
+    :param skip_merge: If "True", skip the merge step.
+    :return: A dictionary mapping GitRepo objects to (status_code, message).
+    """
+    merge_report = {}
+
+    with open(os.path.abspath(conf_file_path), "r", encoding="utf-8") as file:
+        # Read the configuration file - `repos.conf`
+        for line in file:
+            if line.startswith("#"):
+                continue
+            parts = line.split()
+            local_repo = parts[0]
+            layer_name = local_repo.split("/")[-1]
+            token = os.environ.get("GH_PAT")
+            if token is None:
+                fork_url = f"https://github.com/{username}/{layer_name}.git"
+            else:
+                fork_url = (
+                    f"https://x-access-token:{token}@github.com/"
+                    f"{username}/{layer_name}.git"
+                )
+            git_obj = GitRepo(
+                local_repo=local_repo,
+                upstream_repo_url=parts[1],
+                upstream_branch=parts[2],
+                local_base_branch=parts[3],
+                upstream_repo_name=upstream_repo_name,
+                fork_name=fork_name,
+                fork_url=fork_url,
+            )
+            print(f"\n{layer_name}\n")
+            if skip_merge:
+                print("\tUpstream Merge has Been Skipped")
+                merge_report[git_obj] = (0, "Upstream Merge has Been Skipped")
+            else:
+                os.chdir(git_obj.local_repo)
+                merge_report[git_obj] = merge_upstream(
+                    git_obj, force_checkout, merge_branch_name
+                )
+                os.chdir("../..")
+
+    return merge_report
+
+
+def build_and_test(clean_build, rt_target_IP, build_args):
+    """
+    Build images and run tests on a VM if there are no merge errors.
+
+    :param clean_build: Boolean indicating whether to perform a clean build.
+    :param rt_target_IP: The target IP address of the RT system.
+    :param build_args: To build with NI specific arguments.
+    :return: A tuple (status_code, message).
+            Returns (0, None) on success, or error details on failure.
+    """
+    success = setup_env_and_build_packages(build_args, clean_build)
+    if success[0] != 0:
+        return success
+    success = install_and_test_image(rt_target_IP)
+    return success
+
+
+def push_submodules_and_create_PRs(
+    merge_report,
+    merge_branch_name,
+    pr_title,
+    pr_description,
+    username
+):
+    """
+    For each sub-module that was successfully merged and built, push the merge
+    branch to the user's fork and create a pull request targeting the base
+    branch. Updates the push_and_pr_results dictionary with the results of
+    the push and PR steps.
+
+    :param merge_report: Dictionary mapping GitRepo objects to
+                        (status, message).
+    :param merge_branch_name: Name of the branch to push and create PRs from.
+    :param pr_title: Title for the pull request.
+    :param pr_description: Description for the pull request.
+    :param username: GitHub username owning the downstream fork.
+    :return: Dictionary with push and PR results for each sub-module.
+    """
+    push_and_pr_results = {}
+    for git_obj, (status, message) in list(merge_report.items()):
+        if status == 0 and message is not None:
+            os.chdir(git_obj.local_repo)
+            push_and_pr_results[git_obj] = push_branch_and_create_pr(
+                git_obj,
+                merge_branch_name,
+                username,
+                pr_title,
+                pr_description
+            )
+
+    return push_and_pr_results
+
+
+def get_pr_description(work_item_id):
+    """
+    Generate and return the pull request description text.
+
+    :param work_item_id: The work item ID to reference in the PR description.
+    :return: A formatted string containing the PR checklist and work item.
+    """
+    checklist = (
+        "- [x] bitbake packagefeed-ni-core\n"
+        "- [x] bitbake packagegroup-ni-desirable\n"
+        "- [x] bitbake package-index && bitbake nilrt-base-system-image\n"
+        "- [x] Installed BSI on a VM and verified it boots successfully"
+    )
+    work_item_line = (
+        f"\n\nAB#{work_item_id}\n"
+        if work_item_id is not None else ""
+    )
+    return (
+        f"Merge latest from upstream. No conflicts."
+        f"{work_item_line}\n\n{checklist}"
+    )
+
+
+def pull_from_base_branch(branch, upstream_url):
+    """
+    Pull the latest changes from the NILRT repository.
+
+    :param branch: The branch name to pull.
+    :param upstream_url: The URL of the upstream repository.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    git_obj = GitRepo(
+        local_base_branch=branch,
+        upstream_repo_name="upstream",
+        upstream_repo_url=upstream_url,
+    )
+
+    add_remote_details = git_obj.add_remote()
+    if add_remote_details[0] != 0:
+        print(add_remote_details[1])
+        return add_remote_details
+
+    pull_details = git_obj.pull()
+    if pull_details[0] != 0:
+        print(pull_details[1])
+        return pull_details
+
+    return (0, None)
+
+
+def update_meta_nilrt_branch(meta_nilrt_branch):
+    """
+    Pull the latest changes from the meta-nilrt repository.
+
+    :param meta_nilrt_branch: The branch name to pull from the meta-nilrt repo.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    os.chdir("sources/meta-nilrt")
+    # Ensure that the meta-nilrt branch is up to date
+    pull_from_meta_nilrt_details = pull_from_base_branch(
+        meta_nilrt_branch, META_NILRT_URL
+    )
+    os.chdir("../..")
+    if pull_from_meta_nilrt_details[0] != 0:
+        print(pull_from_meta_nilrt_details[1])
+        return pull_from_meta_nilrt_details
+
+    return (0, None)
+
+
+def main():
+    """
+    Main entry point for the upstream merge automation script.
+    Parses arguments, updates repositories, performs merges, builds, tests,
+    pushes, creates PRs, and sends a summary email.
+    """
+    args = parse_args()
+    skip_merge = args.s
+
+    json_config_obj = JsonConfig(
+        automation_conf_path=args.c,
+        work_item_id=args.w
+    )
+
+    setup_logging(json_config_obj.log_level)
+
+    # Ensure that the NILRT branch is up to date (important if repos.conf is
+    # modified)
+    pull_from_nilrt_details = pull_from_base_branch(
+        json_config_obj.nilrt_branch,
+        NILRT_URL
+    )
+    if pull_from_nilrt_details[0] != 0:
+        print(pull_from_nilrt_details[1])
+        return
+
+    merge_report = merge_submodules_with_upstream(
+        json_config_obj.conf_file_path,
+        json_config_obj.force_checkout,
+        json_config_obj.username,
+        json_config_obj.upstream_repo_name,
+        json_config_obj.merge_branch_name,
+        json_config_obj.fork_name,
+        skip_merge,
+    )
+
+    merge_has_errors = any(
+        status != 0 for status, _ in merge_report.values()
+    )
+
+    update_meta_nilrt_branch(json_config_obj.meta_nilrt_branch)
+
+    if merge_has_errors:
+        print(
+            "Merge has errors, skipping build and test."
+        )
+        build_and_test_details = (1, "Merge has Errors")
+    else:
+        build_and_test_details = build_and_test(
+            clean_build=skip_merge,
+            rt_target_IP=json_config_obj.rt_target_IP,
+            build_args=json_config_obj.build_args,
+        )
+
+        if build_and_test_details[0] == 0 and not args.skip_push_and_pr:
+            push_and_pr_results = push_submodules_and_create_PRs(
+                merge_report,
+                json_config_obj.merge_branch_name,
+                "Automated Merge PR",
+                get_pr_description(json_config_obj.work_item_id),
+                json_config_obj.username,
+            )
+            merge_report["Push and pr"] = push_and_pr_results
+
+    merge_report["Build and Test"] = build_and_test_details
+
+    write_log_and_send_email(
+        json_config_obj.email_from,
+        json_config_obj.email_to,
+        merge_report,
+        json_config_obj.email_log_level,
+        args.skip_push_and_pr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/upstream_merge/utils/build.py
+++ b/scripts/dev/upstream_merge/utils/build.py
@@ -1,0 +1,156 @@
+"""
+Utility functions for building core feeds and images in the nilrt
+project.
+"""
+
+import argparse
+
+from .shell_commands import execute_and_stream_cmd_output
+
+
+def setup_env_and_build_packages(args="", clean_build=False):
+    """
+    Build the images for the project.
+    This function orchestrates the steps required to build the images,
+    including setting up the Docker environment, cleaning build feeds and
+    images, and building the core feeds and images.
+
+    :param args: This can be used to select organization-specific build
+        configurations.
+    :param clean_build: A boolean indicating whether to clean the build feeds
+        and images.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    # Step 1: Set up the Docker environment
+    docker = start_docker_setup()
+    if docker[0] != 0:
+        return docker
+    print("\nDocker setup completed.")
+
+    if clean_build:
+        # Step 2: Clean the build feeds and images
+        clean = clean_feeds_and_images(args)
+        if clean[0] != 0:
+            return clean
+        print("\nClean feeds and images completed.")
+
+    # Step 2: Build the core feeds
+    core_feeds = build_core_feeds(args)
+    if core_feeds[0] != 0:
+        return core_feeds
+    print("\nCore feeds build completed.")
+
+    # Step 3: Build the desirable packages
+    desirable_packages = build_desirable_packages()
+    if desirable_packages[0] != 0:
+        return desirable_packages
+    print("\nDesirable packages build completed.")
+
+    # Step 4: Build the core images
+    core_images = build_core_images(args)
+    if core_images[0] != 0:
+        return core_images
+    print("\nCore images build completed.")
+
+    # Return success if all steps are completed
+    return (0, "Building core feeds, safemode and runmode succeeded")
+
+
+def build_desirable_packages():
+    """
+    Build the desirable packages.
+    This step involves running the script to build the extra package feed.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    print("\nBuilding extra package feed...\n")
+    return execute_and_stream_cmd_output(
+        "bash scripts/pipelines/build.desirable.sh"
+    )
+
+
+def clean_feeds_and_images(args=""):
+    """
+    Clean the build feeds and images.
+    This step involves running the script to clean the build feeds and images.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    print("\nCleaning build feeds and images...\n")
+    return execute_and_stream_cmd_output(
+        "bash scripts/pipelines/clean_build.core-feeds_and_core-images.sh "
+        f"{args}"
+    )
+
+
+def start_docker_setup():
+    """
+    Start the Docker setup process.
+    This script initializes the Docker environment required for building
+    images.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    print("\nStarting Docker setup...\n")
+    return execute_and_stream_cmd_output(
+        "bash ./docker/create-build-nilrt.sh"
+    )
+
+
+def build_core_feeds(args=""):
+    """
+    Build the core feeds.
+    This step involves running the script to build the core feeds required
+    for the images.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    print("\nBuilding core feeds...\n")
+    return execute_and_stream_cmd_output(
+        "bash scripts/pipelines/build.core-feeds.sh "
+        f"{args}"
+    )
+
+
+def build_core_images(args=""):
+    """
+    Build the core images.
+    This step involves running the script to build the core images for the
+    project.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    print("\nBuilding core images...\n")
+    return execute_and_stream_cmd_output(
+        "bash scripts/pipelines/build.core-images.sh "
+        f"{args}"
+    )
+
+
+def parse_args():
+    """
+    Parse command-line arguments for building the core feeds and images,
+    allowing passthrough of extra arguments.
+    :return: Tuple of (known_args, unknown_args) as returned by
+    argparse.ArgumentParser.parse_known_args().
+    """
+    parser = argparse.ArgumentParser(
+        description="Building core feeds and images", add_help=True
+    )
+    parser.add_argument(
+        "--org",
+        dest="org",
+        action="store_true",
+        help="Pass --org flag to select organization-specific build configs",
+    )
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    main_args = parse_args()
+    ARGS_STR = "--org" if main_args.org else ""
+    status_code, message = setup_env_and_build_packages(
+        ARGS_STR, clean_build=False
+    )
+    if status_code == 0:
+        print("\nBuild completed successfully.")
+    else:
+        print(
+            f"\nBuild failed with status code {status_code}. Error: {message}"
+        )

--- a/scripts/dev/upstream_merge/utils/git_commands.py
+++ b/scripts/dev/upstream_merge/utils/git_commands.py
@@ -1,0 +1,280 @@
+"""
+Utility functions for git operations.
+"""
+
+from .shell_commands import run_command
+
+
+def git_clone(
+    repo,
+    directory=None,
+    depth=None,
+    capture_output=True
+):
+    """
+    Clone a Git repository.
+    :param repo: URL of the repository to clone.
+    :param directory: Directory to clone into (optional).
+    :param depth: Depth for shallow cloning (optional).
+    :param capture_output: Whether to capture the command output.
+    """
+    if directory is not None:
+        command = f"git clone {repo} {directory}"
+    else:
+        command = f"git clone {repo}"
+    if depth:
+        command += f" --depth {depth}"
+    return run_command(command, capture_output)
+
+
+def git_commit(
+    message="update",
+    amend=False,
+    signoff=False,
+    capture_output=True
+):
+    """
+    Commit changes to the repository.
+    :param message: Commit message.
+    :param amend: Whether to amend the previous commit.
+    :param signoff: Whether to add a Signed-off-by line.
+    :param capture_output: Whether to capture the command output.
+    """
+    command = "git commit"
+    if amend:
+        command += " --amend"
+    if signoff:
+        command += " --signoff"
+    command += f' -m "{message}"'
+    return run_command(command, capture_output)
+
+
+def git_push(
+    remote_repo_name="origin",
+    branch="main",
+    force=False,
+    delete_existing=False,
+    capture_output=True,
+):
+    """
+    Push changes to a remote repository.
+    :param remote_repo_name: Name of the remote repository (default: "origin").
+    :param branch: Branch to push (default: "main").
+    :param force: Whether to force push.
+    :param delete_existing: Whether to delete the branch on the remote.
+    :param capture_output: Whether to capture the command output.
+    """
+    if delete_existing:
+        command = f"git push {remote_repo_name} --delete {branch}"
+    else:
+        command = f"git push {remote_repo_name} {branch}"
+        if force:
+            command += " --force"
+    return run_command(command, capture_output)
+
+
+def git_pull(
+    remote=None,
+    branch=None,
+    rebase=False,
+    capture_output=True
+):
+    """
+    Pull the latest changes from a remote repository.
+    :param remote: Name of the remote repository (optional).
+    :param branch: Branch to pull from (optional).
+    :param rebase: Whether to rebase instead of merging.
+    :param capture_output: Whether to capture the command output.
+    """
+    command = "git pull"
+    if rebase:
+        command += " --rebase"
+    if remote is not None and branch is not None:
+        command += f" {remote} {branch}"
+    return run_command(command, capture_output)
+
+
+def git_branch(
+    branch_name,
+    show_current=False,
+    create=False,
+    delete=False,
+    capture_output=True
+):
+    """
+    Handle branch operations: create, delete, or list branches.
+    :param branch_name: Name of the branch (required for create or delete).
+    :param show_current: Whether to show the current branch.
+    :param create: Whether to create a new branch.
+    :param delete: Whether to delete the branch.
+    :param capture_output: Whether to capture the command output.
+    """
+    if show_current:
+        command = "git branch --show-current"
+    elif create:
+        command = f"git branch {branch_name}"
+    elif delete:
+        command = f"git branch -D {branch_name}"
+    else:
+        command = "git branch"
+    return run_command(command, capture_output)
+
+
+def git_checkout(
+    branch_name,
+    create=False,
+    force_checkout=False,
+    capture_output=True
+):
+    """
+    Checkout a branch, creating it if it doesn't exist.
+    :param branch_name: Name of the branch to checkout.
+    :param force_checkout: Whether to force checkout.
+    :param capture_output: Whether to capture the command output.
+    """
+    if create:
+        git_branch(branch_name, create=True)
+    if force_checkout:
+        command = f"git checkout -f {branch_name}"
+    else:
+        command = f"git checkout {branch_name}"
+    return run_command(command, capture_output)
+
+
+def git_fetch(
+    remote=None,
+    branch=None
+):
+    """
+    Fetch the latest changes from a remote repository.
+    :param remote: Name of the remote repository (optional).
+    :param branch: Branch to fetch (optional).
+    """
+    command = "git fetch"
+    if remote:
+        command += f" {remote}"
+    if branch:
+        command += f" {branch}"
+    return run_command(command, capture_output=True)
+
+
+def git_remote(
+    name=None,
+    url=None,
+    remove=False,
+    capture_output=True
+):
+    """
+    Handle listing, adding, and removing remote repositories.
+    :param name: Name of the remote repository.
+    :param url: URL of the remote repository (required for adding).
+    :param remove: Whether to remove the remote repository.
+    :param capture_output: Whether to capture the command output.
+    """
+    if name is not None:
+        if url is not None:
+            return run_command(f"git remote add {name} {url}", capture_output)
+        if remove:
+            return run_command(f"git remote remove {name}", capture_output)
+
+    return run_command("git remote", capture_output)
+
+
+def git_merge(
+    branch_name,
+    message="Merge Branch",
+    no_ff=False,
+    signoff=False,
+    capture_output=True
+):
+    """
+    Merge a branch into the current branch.
+    :param branch_name: Name of the branch to merge.
+    :param message: Commit message for the merge.
+    :param no_ff: Whether to use a no-fast-forward merge.
+    :param signoff: Whether to sign off the merge.
+    :param capture_output: Whether to capture the command output.
+    """
+    if signoff:
+        command = (
+            f'git merge {branch_name} --signoff -m "{message}"'
+        )
+    else:
+        command = f'git merge {branch_name} -m "{message}"'
+
+    if no_ff:
+        command += " --no-ff"
+    return run_command(command, capture_output)
+
+
+def git_diff(
+    target="HEAD",
+    compare_with=None,
+    staged=False,
+    capture_output=True
+):
+    """
+    Show differences between commits or the working directory.
+    :param target: Target commit or branch (default: "HEAD").
+    :param compare_with: Commit or branch to compare with (optional).
+    :param staged: Whether to show staged changes.
+    :param capture_output: Whether to capture the command output.
+    """
+    if compare_with:
+        command = f"git diff {target} {compare_with}"
+    else:
+        command = "git diff --staged" if staged else "git diff"
+    return run_command(command, capture_output)
+
+
+def git_pull_request(
+    title,
+    body="",
+    repo="",
+    base_branch="main",
+    head_branch=None,
+    capture_output=True
+):
+    """
+    Create a pull request using the GitHub CLI.
+    :param title: Title of the pull request.
+    :param body: Body/description of the pull request.
+    :param base_branch: Base branch for the pull request
+                        (default: "main").
+    :param head_branch: Head branch for the pull request
+                        (default: current branch).
+    :param capture_output: Whether to capture the command output.
+    """
+    if head_branch is None:
+        head_branch = run_command(
+            "git rev-parse --abbrev-ref HEAD", capture_output=True
+        )[1]
+    if repo == "":
+        command = (
+            f'gh pr create --title "{title}" --body "{body}" '
+            f'--base {base_branch} --head {head_branch}'
+        )
+    else:
+        command = (
+            f'gh pr create --repo {repo} --title "{title}" --body "{body}" '
+            f'--base {base_branch} --head {head_branch}'
+        )
+    return run_command(command, capture_output)
+
+
+def send_email(
+    to_address,
+    subject,
+    file
+):
+    """
+    Send an email using git send-email.
+    :param to_address: Recipient email address.
+    :param subject: Subject of the email.
+    :param file: File to attach to the email.
+    """
+    command = (
+        f'git send-email --to {to_address} --subject "{subject}" '
+        f'--confirm=never --encoding=UTF-8 {file}'
+    )
+    return run_command(command)

--- a/scripts/dev/upstream_merge/utils/git_repo.py
+++ b/scripts/dev/upstream_merge/utils/git_repo.py
@@ -1,0 +1,194 @@
+"""
+Defines the GitRepo class for encapsulating details and operations
+on a Git repoitory.
+"""
+
+import os
+
+from .git_commands import (
+    run_command,
+    git_checkout,
+    git_branch,
+    git_fetch,
+    git_merge,
+    git_remote,
+    git_pull,
+    git_push,
+    git_pull_request,
+    git_diff,
+)
+
+
+class GitRepo:
+    """
+    Encapsulates details and operations for a Git repository,
+    including remotes, branches, and merges.
+    """
+
+    def __init__(
+        self,
+        local_repo=None,
+        upstream_repo_url=None,
+        upstream_branch=None,
+        local_base_branch=None,
+        upstream_repo_name=None,
+        fork_name=None,
+        fork_url=None,
+    ):
+        # Initialize the GitRepo object with repository details
+        # as specified in `repos.conf`.
+        self.local_repo = os.getcwd() + f"/{local_repo}"
+        self.local_base_branch = local_base_branch
+        self.upstream_branch = upstream_branch
+        self.upstream_repo_url = upstream_repo_url
+        self.upstream_repo_name = upstream_repo_name
+        self.fork_name = fork_name
+        self.fork_url = fork_url
+
+    def get_current_commit(self):
+        """
+        Get the current HEAD commit hash.
+        :param capture_output: Whether to capture the command output.
+        :return: The current commit hash.
+        """
+        return run_command("git rev-parse HEAD")[1]
+
+    def branch_exists(
+        self,
+        branch_name,
+        fork_name=None,
+        check_on_remote=False,
+        capture_output=True
+    ):
+        """
+        Check if a branch exists locally.
+        :param branch_name: Name of the branch to check.
+        :param capture_output: Whether to capture the command output.
+        :return: True if the branch exists, False otherwise.
+        """
+        if check_on_remote:
+            if fork_name is None:
+                fork_name = self.upstream_repo_name
+            result = run_command(
+                f"git ls-remote --heads {fork_name} {branch_name}",
+                capture_output
+            )
+            if result[0] == 0 and result[1] != "":
+                return True
+            return False
+        return (
+            run_command(f"git rev-parse --verify {branch_name}",
+                        capture_output)[0] == 0
+        )
+
+    def checkout_branch(
+        self,
+        branch_name,
+        create=False,
+        force_checkout=False
+    ):
+        """Switch to the given branch."""
+        return git_checkout(branch_name, create, force_checkout)
+
+    def delete_branch(
+        self,
+        branch_name
+    ):
+        """Delete a local branch."""
+        return git_branch(branch_name, delete=True)
+
+    def fetch_branch(
+        self,
+        upstream_repo_name=None,
+        repo_branch=None
+    ):
+        """Fetch a remote branch."""
+        if upstream_repo_name is None:
+            upstream_repo_name = self.upstream_repo_name
+        if repo_branch is None:
+            repo_branch = self.upstream_branch
+        return git_fetch(upstream_repo_name, repo_branch)
+
+    def merge_branch(
+        self,
+        branch_name,
+        message="Merge"
+    ):
+        """Merge a remote branch into the current branch."""
+        return git_merge(
+            branch_name,
+            message,
+            signoff=True,
+            capture_output=True
+        )
+
+    def add_remote(
+        self,
+        upstream_repo_name=None,
+        repo_url=None
+    ):
+        """Add a new remote."""
+        if upstream_repo_name is None:
+            upstream_repo_name = self.upstream_repo_name
+        if repo_url is None:
+            repo_url = self.upstream_repo_url
+
+        existing_remotes = git_remote(capture_output=True)[1].splitlines()
+
+        if upstream_repo_name in existing_remotes:
+            git_remote(upstream_repo_name, remove=True)
+
+        return git_remote(upstream_repo_name, repo_url)
+
+    def diff(
+        self
+    ):
+        """Check if there are differences in the last merge."""
+        return git_diff(compare_with="HEAD~1", capture_output=True)
+
+    def pull(
+        self,
+        branch_name=None,
+        upstream_repo_name=None
+    ):
+        """Pull latest changes from the remote tracking branch."""
+        if upstream_repo_name is None:
+            upstream_repo_name = self.upstream_repo_name
+        if branch_name is None:
+            branch_name = self.local_base_branch
+        return git_pull(
+            remote=upstream_repo_name, branch=branch_name, capture_output=True
+        )
+
+    def push(
+        self,
+        branch_name,
+        upstream_repo_name=None,
+        force=False,
+        delete_existing=False
+    ):
+        """Push a branch to the remote repository."""
+        if upstream_repo_name is None:
+            upstream_repo_name = self.upstream_repo_name
+        return git_push(
+            upstream_repo_name,
+            branch_name,
+            force,
+            delete_existing
+        )
+
+    def create_pull_request(
+        self,
+        title,
+        repo="",
+        body="",
+        base_branch="main",
+        head_branch=None
+    ):
+        """Create a pull request on GitHub using the GitHub CLI (gh)."""
+
+        if head_branch is None:
+            head_branch = self.local_base_branch
+        return git_pull_request(
+            title, body, repo, base_branch, head_branch, capture_output=True
+        )

--- a/scripts/dev/upstream_merge/utils/push_branch_and_create_pr.py
+++ b/scripts/dev/upstream_merge/utils/push_branch_and_create_pr.py
@@ -1,0 +1,142 @@
+"""
+Functions for pushing branches to forks and creating pull requests.
+"""
+
+import sys
+import argparse
+
+from .git_repo import GitRepo
+
+
+def push_branch_and_create_pr(
+    git_obj,
+    branch_name,
+    username,
+    pr_title,
+    pr_description
+):
+    """
+    Push the specified branch to the fork remote and create a pull request.
+
+    :param git_obj: The GitRepo object to interact with the repository.
+    :param branch_name: The name of the branch to push and create a PR from.
+    :param work_item_id: The work item ID to reference in the PR description.
+    :param username: The GitHub username owning the downstream fork.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    push_details = push_branch(git_obj, branch_name)
+    if push_details[0] != 0:
+        print(push_details[1])
+        return push_details
+
+    pr_details = create_pr(
+        git_obj,
+        branch_name,
+        username,
+        pr_title,
+        pr_description
+    )
+    if pr_details[0] != 0:
+        print(pr_details[1])
+        return pr_details
+
+    return (0, None)
+
+
+def push_branch(
+    git_obj,
+    branch_name
+):
+    """
+    Push the specified branch to the fork remote,
+    deleting it first if it already exists.
+
+    :param git_obj: The GitRepo object to interact with the repository.
+    :param branch_name: The name of the branch to push.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    add_remote_details = git_obj.add_remote(
+                            git_obj.fork_name,
+                            git_obj.fork_url
+                        )
+    if add_remote_details[0] != 0:
+        print(add_remote_details[1])
+        return add_remote_details
+
+    if git_obj.branch_exists(
+        branch_name,
+        git_obj.fork_name,
+        check_on_remote=True
+    ):
+        push_delete_details = git_obj.push(
+            branch_name, git_obj.fork_name, delete_existing=True
+        )
+        if push_delete_details[0] != 0:
+            print(push_delete_details[1])
+            return push_delete_details
+
+    push_details = git_obj.push(branch_name, git_obj.fork_name)
+    if push_details[0] != 0:
+        print(push_details[1])
+        return push_details
+
+    return (0, None)
+
+
+def create_pr(
+    git_obj,
+    branch_name,
+    username,
+    pr_title,
+    pr_description=None
+):
+    """
+    Create a pull request using the provided GitRepo object.
+
+    :param git_obj: The GitRepo object to interact with the repository.
+    :param branch_name: The name of the branch where the merge was performed.
+    :param username: The GitHub username owning the downstream fork.
+    :return: A tuple (status_code, message). Returns (0, None) on success.
+    """
+    pr_details = git_obj.create_pull_request(
+        title=pr_title,
+        body=pr_description,
+        base_branch=git_obj.local_base_branch,
+        head_branch=f"{username}:{branch_name}",
+    )
+    if pr_details[0] != 0:
+        print(pr_details[1])
+        return pr_details
+
+    return (0, None)
+
+
+def parse_args():
+    """
+    Parse command-line arguments for the Push and PR script.
+
+    :return: Parsed arguments as returned by
+            argparse.ArgumentParser.parse_args().
+    """
+    parser = argparse.ArgumentParser(description="Push and PR script")
+    parser.add_argument(
+        "-t", type=str, help="Pull request title", default="Automated Merge PR"
+    )
+    parser.add_argument("-u", type=str, help="Username", default=None)
+    parser.add_argument("-br", type=str, help="Branch name", default=None)
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    git_obj = GitRepo(local_base_branch=args.br)
+
+    status_code, message = push_branch_and_create_pr(
+        git_obj, git_obj.local_base_branch, args.u, args.t, None
+    )
+    if status_code != 0:
+        print(f"Error code: {status_code}, message: {message}")
+        sys.exit()
+
+    print("Push and PR created successfully.")

--- a/scripts/dev/upstream_merge/utils/shell_commands.py
+++ b/scripts/dev/upstream_merge/utils/shell_commands.py
@@ -1,0 +1,94 @@
+"""Utility functions for executing shell commands."""
+
+import subprocess
+import shlex
+import sys
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def run_command(command, capture_output=True):
+    """
+    Run a shell command and optionally capture the output.
+
+    :param command: Shell command as a string.
+    :param capture_output: Whether to capture the output.
+    :return: (return_code, output) - return code and
+                                    output string (or None if not captured).
+    """
+    print(command)
+    logger.info("Running command: %s", command)
+    formatted_command = shlex.split(command)
+    try:
+        if capture_output:
+            result = subprocess.run(
+                formatted_command, capture_output=True, text=True, check=True
+            )
+            logger.info(
+                "Command output: %s",
+                result.stdout.strip() + result.stderr.strip()
+            )
+            return (
+                result.returncode,
+                result.stdout.strip() + result.stderr.strip()
+            )
+
+        result = subprocess.run(
+            formatted_command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=True,
+        )
+        logger.info(
+            "Command output: %s",
+            result.stdout.strip() + result.stderr.strip()
+        )
+        return result.returncode, None
+    except subprocess.CalledProcessError as err:
+        output = (err.output or "") + (err.stderr or "")
+        logger.critical("Exception running command: %s\n"
+                        "Output:\n%s", str(err), output)
+        return (
+            err.returncode,
+            f"Error running command '{command}': {str(err)}\n"
+            f"Output:\n{output}",
+        )
+    except Exception as err:
+        logger.critical("Exception running command: %s", str(err))
+        return err.returncode, f"Error running command '{command}': {str(err)}"
+
+
+def execute_and_stream_cmd_output(command):
+    """
+    Execute a command and yield its output line by line in real-time.
+
+    :param command: Command to execute as a string.
+    :yield: Lines of output from the command.
+    """
+    print(command)
+    logger.info("Running command: %s", command)
+    try:
+        process = subprocess.Popen(
+            command,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+
+        retval = ""
+        while True:
+            nextline = process.stdout.readline()
+            retval += nextline
+            if nextline == "" and process.poll() is not None:
+                break
+            sys.stdout.write(nextline)
+            sys.stdout.flush()
+
+        logger.info("Command output: %s", retval)
+        return process.returncode, retval
+    except Exception as err:
+        logger.critical("Exception running command: %s", str(err))
+        return 1, f"Error running command '{command}': {str(err)}"

--- a/scripts/dev/upstream_merge/utils/test.py
+++ b/scripts/dev/upstream_merge/utils/test.py
@@ -1,0 +1,220 @@
+"""Functions for testing built images on a VM via SSH."""
+
+import os
+import time
+
+from .shell_commands import execute_and_stream_cmd_output
+
+BUILD_DIR = "/build/tmp-glibc/deploy/images/x64/"
+SAFEMODE_IMAGE = "nilrt-safemode-rootfs-x64.tar.gz"
+RUNMODE_IMAGE = "nilrt-base-system-image-x64.tar"
+
+
+def install_and_test_image(ssh_connection):
+    """
+    perform the following steps to test the built images on the target machine:
+    1. set safemode
+    2. reboot
+    3. format the machine, enable sshd, and reboot
+    4. current os version
+    5. install safemode image
+    6. verify os version
+    7. install runmode image
+    8. verify os version
+    """
+    print("\nStarting OS test...")
+
+    # Step 1: Set safemode
+    print("Setting safemode...")
+    result = execute_and_stream_cmd_output(
+        f'ssh -o StrictHostKeyChecking=no {ssh_connection} "/etc/init.d/nisetbootmode force-safemode"'
+    )
+    if result[0] != 0:
+        return result
+
+    # Step 2: Reboot
+    print("Rebooting after setting safemode...")
+    reboot = reboot_machine(ssh_connection)
+    if reboot[0] != 0:
+        return reboot
+    time.sleep(90)  # Wait for reboot
+
+    # Step 3: Format, enable sshd, and reboot
+    result = format_and_enable_ssh(ssh_connection)
+    if result[0] != 0:
+        return result
+
+    # Step 4: Get current OS version
+    print("Verifying current OS version...")
+    current_os = verify_os_version(ssh_connection)
+    if current_os[0] != 0:
+        return current_os
+    print(f"Current OS version:\n{current_os[1]}")
+
+    # Step 5: Install safemode image
+    print("Installing safemode image...")
+    safemode_install = test_safemode_installation(ssh_connection)
+    if safemode_install[0] != 0:
+        return safemode_install
+
+    # Step 6: Verify OS version after safemode install
+    print("Verifying OS version after safemode installation...")
+    os_after_safemode = verify_os_version(ssh_connection)
+    if os_after_safemode[0] != 0:
+        return os_after_safemode
+    print(f"OS version after safemode installation:\n{os_after_safemode[1]}")
+
+    # Step 7: Install runmode image
+    print("Installing runmode image...")
+    runmode_install = test_runmode_installation(ssh_connection)
+    if runmode_install[0] != 0:
+        return runmode_install
+
+    # Step 8: Verify OS version after runmode install
+    print("Verifying OS version after runmode installation...")
+    os_after_runmode = verify_os_version(ssh_connection)
+    if os_after_runmode[0] != 0:
+        return os_after_runmode
+    print(f"OS version after runmode installation:\n{os_after_runmode[1]}")
+
+    return os_after_runmode
+
+
+def format_and_enable_ssh(ssh_connection):
+    """
+    Format the machine, enable sshd, and reboot.
+    """
+    print("Formatting the machine, enabling sshd, and rebooting...")
+    result = execute_and_stream_cmd_output(
+        f"ssh -o StrictHostKeyChecking=no {ssh_connection} \"nisystemformat -f -t ext4 -n all && "
+        "sed -i 's/^sshd.enabled=.*/sshd.enabled=True/' "
+        "/etc/natinst/share/ni-rt.ini && reboot\""
+    )
+    if result[0] != 0:
+        return result
+    time.sleep(90)  # Wait for reboot
+
+    return (0, None)
+
+
+def test_safemode_installation(ssh_connection):
+    """
+    Copy, extract, and install the safemode image on the target machine.
+    """
+    current_directory = os.getcwd()
+    copy = execute_and_stream_cmd_output(
+        f"scp {current_directory}{BUILD_DIR}{SAFEMODE_IMAGE} "
+        f"{ssh_connection}:/home/admin"
+    )
+    if copy[0] != 0:
+        return copy
+
+    extract_and_install = extract_and_install_safemode_image(ssh_connection)
+    if extract_and_install[0] != 0:
+        return extract_and_install
+
+    reboot = reboot_machine(ssh_connection)
+    if reboot[0] != 0:
+        return reboot
+
+    time.sleep(90)  # Wait for the machine to reboot
+
+    return (0, None)
+
+
+def test_runmode_installation(ssh_connection):
+    """
+    Copy, extract, and install the runmode image on the target machine.
+    """
+    current_directory = os.getcwd()
+    copy = execute_and_stream_cmd_output(
+        f"scp -o StrictHostKeyChecking=no {current_directory}{BUILD_DIR}{RUNMODE_IMAGE} "
+        f"{ssh_connection}:/mnt/userfs"
+    )
+    if copy[0] != 0:
+        return copy
+
+    extract_and_install = extract_and_install_runmode_image(ssh_connection)
+    if extract_and_install[0] != 0:
+        return extract_and_install
+
+    reboot = reboot_machine(ssh_connection)
+    if reboot[0] != 0:
+        return reboot
+
+    time.sleep(300)  # Wait for the machine to reboot
+
+    return (0, None)
+
+
+def extract_and_install_safemode_image(ssh_connection):
+    """
+    Extract and install the safemode image on the target machine.
+    """
+    print("Extracting safemode image on target machine...")
+    return execute_and_stream_cmd_output(
+        f'ssh -o StrictHostKeyChecking=no {ssh_connection} "tar xf {SAFEMODE_IMAGE} -C /boot/.safe/"'
+    )
+
+
+def extract_and_install_runmode_image(ssh_connection):
+    """
+    Extract and install the runmode image on the target machine.
+    """
+    print("Extracting runmode image on target machine...")
+
+    # Change to /mnt/userfs and extract the tar
+    first_cmd = execute_and_stream_cmd_output(
+        f'ssh -o StrictHostKeyChecking=no {ssh_connection} "cd /mnt/userfs && tar xf {RUNMODE_IMAGE}"'
+    )
+    if first_cmd[0] != 0:
+        return first_cmd
+
+    # Extract data.tar.gz and run postinst
+    second_cmd = execute_and_stream_cmd_output(
+        f'ssh -o StrictHostKeyChecking=no {ssh_connection} "cd /mnt/userfs && tar xf data.tar.gz -C '
+        f'/mnt/userfs && ./postinst"'
+    )
+    if second_cmd[0] != 0:
+        return second_cmd
+
+    # Remove the tar, data.tar.gz, and postinst files
+    cleanup_cmd = execute_and_stream_cmd_output(
+        f'ssh -o StrictHostKeyChecking=no {ssh_connection} "cd /mnt/userfs && rm -f {RUNMODE_IMAGE} '
+        f'data.tar.gz postinst"'
+    )
+    if cleanup_cmd[0] != 0:
+        return cleanup_cmd
+
+    return (0, None)
+
+
+def reboot_machine(ssh_connection):
+    """
+    Reboot the target machine.
+    """
+    print("Rebooting the machine...")
+    return execute_and_stream_cmd_output(f'ssh -o StrictHostKeyChecking=no {ssh_connection} "reboot"')
+
+
+def verify_os_version(ssh_connection):
+    """
+    Verify the OS version on the target machine.
+    """
+    print("Verifying OS version...")
+    return execute_and_stream_cmd_output(
+        f'ssh -o StrictHostKeyChecking=no {ssh_connection} "cat /etc/os-release"'
+    )
+
+
+if __name__ == "__main__":
+    # Example usage:
+    SSH_CONNECTION = ""
+    status_code, message = install_and_test_image(SSH_CONNECTION)
+    if status_code == 0:
+        print("\n OS test completed successfully.")
+    else:
+        print(
+            f"\n OS test failed with status code {status_code}. "
+            f"Error: {message}"
+        )

--- a/scripts/pipelines/build.core-feeds.sh
+++ b/scripts/pipelines/build.core-feeds.sh
@@ -2,7 +2,7 @@
 
 SCRIPT_ROOT=$(realpath $(dirname $BASH_SOURCE))
 
-. "${SCRIPT_ROOT}/build.common.sh"
+. "${SCRIPT_ROOT}/build.common.sh" $@
 
 echo "INFO: Building the core package feed."
 bitbake packagefeed-ni-core

--- a/scripts/pipelines/build.core-images.sh
+++ b/scripts/pipelines/build.core-images.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SCRIPT_ROOT=$(realpath $(dirname $BASH_SOURCE))
+
+. "${SCRIPT_ROOT}/build.common.sh" $@
+
+echo "INFO: Building safemode rootfs "
+bitbake nilrt-safemode-rootfs
+echo "INFO: Building base system image "
+bitbake nilrt-base-system-image

--- a/scripts/pipelines/build.desirable.sh
+++ b/scripts/pipelines/build.desirable.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+SCRIPT_ROOT=$(realpath $(dirname $BASH_SOURCE))
+
+. "${SCRIPT_ROOT}/build.common.sh" $@
+
+echo "INFO: Building the extra package feed."
+bitbake packagegroup-ni-desirable

--- a/scripts/pipelines/clean.core-feeds_and_core-images.sh
+++ b/scripts/pipelines/clean.core-feeds_and_core-images.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SCRIPT_ROOT=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+
+. "${SCRIPT_ROOT}/build.common.sh" $@
+
+echo "INFO: Cleaning the core package feed and the images."
+
+bitbake -c cleanall packagefeed-ni-core
+bitbake -c cleanall package-index
+bitbake -c cleanall linux-nilrt
+bitbake -c cleanall nilrt-safemode-rootfs
+bitbake -c cleanall nilrt-base-system-image
+bitbake -c cleanall nilrt-recovery-media


### PR DESCRIPTION
# Justification
[AB#3174362](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3174362)

Currently, upstream merge is handled by running [this](https://github.com/ni/nilrt/blob/nilrt/master/hardknott/scripts/dev/upstream_merge/upstream_merge.sh) shell script. Although the script is perfectly capable of merging new commits to the existing ni forks, testing the new changes and creating PRs for the forks of each submodule is still a manual process. The current PR takes care of automating this step as well.

# Implementation
This automation streamlines the process of merging upstream changes into the nilrt repository, building core images, and testing them on a VM, and automates PR creation and email notifications. It reduces manual effort, ensures the fork stays up-to-date.

The original shell script has now been rewritten as a python script such that it can be reused by other scripts we may create in the future.

# Testing
These changes have been tested on my fork by running the full automation workflow, including merge, build, test, and PR creation.

[This](https://github.com/pratheekshasn/nilrt/pull/2) PR was created by running the push_branch_and_create_pr script.