### PR TITLE
high-sev-cve-to-json: Update to skip -native packages

### DIFF
--- a/scripts/pipelines/high-sev-cve-to-json.py
+++ b/scripts/pipelines/high-sev-cve-to-json.py
@@ -3,8 +3,8 @@ from argparse import ArgumentParser
 from pathlib import Path
 import json
 import os
+import re
 import sys
-
 
 parser = ArgumentParser(
     description="Parses a directory of OE cve_check json files, and writes the unpatched, high-severity values to the output file.",
@@ -30,7 +30,8 @@ JSON_PACKAGE_SEC_FIELDS = [
 ]
 
 EXCLUDED_PACKAGES = [
-    'linux-nilrt'
+    'linux-nilrt',
+    '.*-native'
 ]
 
 EXCLUDED_STATUSES = [
@@ -38,6 +39,7 @@ EXCLUDED_STATUSES = [
     'Patched'
 ]
 
+CVE_SEVERITY_THRESHOLD = 7.0
 
 def skip_cve(issue):
     if issue['status'] in EXCLUDED_STATUSES:
@@ -52,14 +54,15 @@ def skip_cve(issue):
     score_versions.sort(reverse=True)
     for score in score_versions:
         CVSS = float(issue[score])
-        if CVSS < 7.0 and not CVSS == 0.0:
+        if CVSS < CVE_SEVERITY_THRESHOLD and not CVSS == 0.0:
             return True
     return False
 
 
 def get_cves(package):
-    if package['name'] in EXCLUDED_PACKAGES:
-        return None
+    for excluded_package in EXCLUDED_PACKAGES:
+        if re.fullmatch(excluded_package, package['name']):
+            return None
 
     package_info = {}
     for field in JSON_PACKAGE_SEC_FIELDS:
@@ -88,7 +91,12 @@ for root, dirs, fils in os.walk(args.cve_directory):
         cve_file = os.path.join(root, fil)
         with open(cve_file, 'r') as fp_cve:
             package_cves = json.load(fp_cve)
-            new_cve = get_cves(package_cves.get(JSON_PACKAGE_FIELD)[0])
+            try:
+                json_package_field = package_cves.get(JSON_PACKAGE_FIELD)[0]
+            except AttributeError:
+                sys.stdout.write(f'{fil} is not formatted as a CVE json file, skipping.\n')
+                continue
+            new_cve = get_cves(json_package_field)
             if new_cve:
                 cves.extend(new_cve)
         sys.stderr.write('\n')


### PR DESCRIPTION
# Changes
Update `high-sev-cve-to-json.py` to skip `.*-native` packages
Added catch for non-cve json files


# Testing
* [x] Executed against oe-core/cve folder and verified output


# Process
* [x] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.


__Suggested Reviewers:__
* @ni/rtos
