### PR TITLE
high-sev-cve: Fix logic that skipped high sev CVEs

### DIFF
--- a/scripts/pipelines/high-sev-cve-to-json.py
+++ b/scripts/pipelines/high-sev-cve-to-json.py
@@ -54,9 +54,12 @@ def skip_cve(issue):
     score_versions.sort(reverse=True)
     for score in score_versions:
         CVSS = float(issue[score])
-        if CVSS < CVE_SEVERITY_THRESHOLD and not CVSS == 0.0:
-            return True
-    return False
+        if CVSS == 0.0:
+            continue
+
+        if CVSS >= CVE_SEVERITY_THRESHOLD:
+            return False
+    return True
 
 
 def get_cves(package):
@@ -93,7 +96,7 @@ for root, dirs, fils in os.walk(args.cve_directory):
             package_cves = json.load(fp_cve)
             try:
                 json_package_field = package_cves.get(JSON_PACKAGE_FIELD)[0]
-            except AttributeError:
+            except (AttributeError, TypeError):
                 sys.stdout.write(f'{fil} is not formatted as a CVE json file, skipping.\n')
                 continue
             new_cve = get_cves(json_package_field)


### PR DESCRIPTION
# Changes
Fix logic that skipped high severity CVEs if "earlier" scores were under the threshold


# Testing
Executed against CVE folder for rtos_oe_feeds 25.8d33


# Process
* [ ] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.


__Suggested Reviewers:__
* @ni/rtos
