### PR TITLE
repos.conf: Update meta-sdr to use the walnascar branch

### DIFF
--- a/scripts/dev/upstream_merge/repos.conf
+++ b/scripts/dev/upstream_merge/repos.conf
@@ -6,7 +6,7 @@ sources/meta-selinux         https://git.yoctoproject.org/meta-selinux          
 sources/openembedded-core    https://git.openembedded.org/openembedded-core        scarthgap             nilrt/master/scarthgap
 sources/meta-virtualization  https://git.yoctoproject.org/meta-virtualization      scarthgap             nilrt/master/scarthgap
 sources/meta-security        https://git.yoctoproject.org/meta-security            scarthgap             nilrt/master/scarthgap
-sources/meta-sdr             https://github.com/balister/meta-sdr                  master                nilrt/master/scarthgap
+sources/meta-sdr             https://github.com/balister/meta-sdr                  walnascar             nilrt/master/scarthgap
 sources/meta-qt5             https://github.com/meta-qt5/meta-qt5                  scarthgap             nilrt/master/scarthgap
 sources/meta-qt5-extra       https://github.com/schnitzeltony/meta-qt5-extra       master                nilrt/master/scarthgap
 sources/meta-rauc            https://github.com/rauc/meta-rauc                     scarthgap             nilrt/master/scarthgap


### PR DESCRIPTION
The meta-sdr master branch recently dropped support for scarthgap. The maintainer suggested we pull from the walnascar branch that still has scarthgap support.

# Changes

Update repos.conf to have meta-sdr use the walnascar branch instead of master.



__Suggested Reviewers:__
* @ni/rtos
