### PR TITLE
CHANGELOG: Update for 25.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,31 @@ This changelog attempts to conform to the changelog spec on [keepachangelog.org]
 The evergreen, canonical changelog for *all NILRT branches* can be [found here](https://github.com/ni/nilrt/blob/HEAD/CHANGELOG.md).
 
 ## Latest Updates
-* nilrt: 307
-* meta-nilrt: 852
-* linux: 235
+* nilrt: 320
+* meta-nilrt: 869
+* linux: 254
+
+----
+## 11.3
+Branch: `nilrt/25.8/scarthgap`
+
+### nilrt
+
+#### Changed
+- [Enabled](https://github.com/ni/linux/pull/242) legacy cgroups v1 cpusets.
+- [Enabled](https://github.com/ni/linux/pull/245) scheduler's debugfs interface.
+
+### meta-nilrt
+
+
+#### Added
+- [Added](https://github.com/ni/meta-nilrt/pull/834) additional kernel modules to feeds.
+- [Added](https://github.com/ni/meta-nilrt/pull/853) perfetto to extras feed.
+- [Added](https://github.com/ni/meta-nilrt/pull/854) usbguard to extras feed.
+
+#### Changed
+- [Upgraded](https://github.com/ni/meta-nilrt/pull/862) `linux-nilrt` to `6.12`.
+- [Disabled](https://github.com/ni/meta-nilrt/pull/864) fair server in 6.12 kernel to prevent priority inversion.
 
 
 ----
@@ -416,6 +438,13 @@ Branch: `nilrt/22.5/hardknott`
 - [Removed](https://github.com/ni/meta-nilrt/pull/277) the `restore` images and `lvcomms` images. The distributions that required these images are not supported in newer versions.
 - [Removed](https://github.com/ni/meta-nilrt/pull/355) boot attestation based on now dead upstream code.
 - [Removed](https://github.com/ni/meta-nilrt/pull/290) packages dropped from upstream.
+
+
+----
+## 8.25
+Branch: `nilrt/25.8/sumo`
+
+No changes.
 
 
 ----


### PR DESCRIPTION
# Changes

CHANGELOG update for 25.8 release

WI: [AB#3126227](https://dev.azure.com/ni/DevCentral/_workitems/edit/3126227)

# Testing

None

# Process

- [x] To be cherry-picked to `nilrt/25.8/scarthgap` and `nilrt/master/next`