### PR TITLE
high-sev-cve: enable -native packages

### DIFF
--- a/scripts/pipelines/high-sev-cve-to-json.py
+++ b/scripts/pipelines/high-sev-cve-to-json.py
@@ -31,7 +31,6 @@ JSON_PACKAGE_SEC_FIELDS = [
 
 EXCLUDED_PACKAGES = [
     'linux-nilrt',
-    '.*-native'
 ]
 
 EXCLUDED_STATUSES = [


### PR DESCRIPTION
# Changes
Enable "-native" packages to be captured by high-sev-cve-to-json.py
[AB#3477073](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3477073)


# Testing
Executed locally on latest build of `rtos_oe_feed` and verified "-native" packages are listed.


# Process
* [X] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.


__Suggested Reviewers:__
* @ni/rtos
