### PR TITLE
Add meta-erlang layer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,10 @@
 	path = sources/meta-cloud-services
 	url = ../meta-cloud-services.git
 	branch = nilrt/master/next
+[submodule "sources/meta-erlang"]
+	path = sources/meta-erlang
+	url = ../meta-erlang.git
+	branch = nilrt/master/next
 [submodule "sources/meta-openembedded"]
 	path = sources/meta-openembedded
 	url = ../meta-openembedded.git

--- a/scripts/dev/upstream_merge/repos.conf
+++ b/scripts/dev/upstream_merge/repos.conf
@@ -1,6 +1,7 @@
 #local_repo                  upstream_repo                                         upstream_branch       local_base_branch
 sources/bitbake              https://git.openembedded.org/bitbake                  master                nilrt/master/next
 sources/meta-cloud-services  https://git.yoctoproject.org/meta-cloud-services      master                nilrt/master/next
+sources/meta-erlang          https://github.com/meta-erlang/meta-erlang            master                nilrt/master/next
 sources/meta-openembedded    https://git.openembedded.org/meta-openembedded        master                nilrt/master/next
 sources/meta-selinux         https://git.yoctoproject.org/meta-selinux             master                nilrt/master/next
 sources/openembedded-core    https://git.openembedded.org/openembedded-core        master                nilrt/master/next


### PR DESCRIPTION
# Changes

This PR adds `meta-erlang` layer and adds it entry in the `repos.conf`.

Erlang-layer ( [Source](https://git.yoctoproject.org/meta-cloud-services/tree/meta-openstack/conf/layer.conf#n21) ) is a dependency of the OpenStack layer.
Previously, the Erlang layer was part of meta-cloud-services, but it was removed and split into its own repo (meta-erlang, [commit ID](https://github.com/ni/meta-cloud-services/commit/d20e8a8c2f8ce1ddcf0843e4a35a32e71e5aabef)).


# Testing

N.A.


# Process

* [x] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.


__Suggested Reviewers:__
* @ni/rtos
