### PR TITLE
nilrt: switch TMPDIR from tmp-glibc to tmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
 
     The resulting ipk files that can be installed through opkg exist at the following directory:
 
-        tmp-glibc/deploy/ipk/...
+        tmp/deploy/ipk/...
 
 6. #### Building package feeds
     The NILRT repo has scripting in the [`:scripts/pipelines/`](https://github.com/ni/nilrt/tree/HEAD/scripts/pipelines) directory, which can be used to automate the process of building package feeds. The NI build pipelines use these scripts directly - so they are canonical.
@@ -114,7 +114,7 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
 
         The resulting root file system images for the NILRT safemode image is located at the following paths:
 
-            tmp-glibc/deploy/images/x64/nilrt-safemode-rootfs-x64.tar.gz
+            tmp/deploy/images/x64/nilrt-safemode-rootfs-x64.tar.gz
 
         You can install this on target by copying the file over to the target and running the following command:
 
@@ -126,7 +126,7 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
 
         The resulting root file system images for the NILRT runmode image is located at the following paths:
 
-            tmp-glibc/deploy/images/x64/nilrt-base-system-image-x64.tar
+            tmp/deploy/images/x64/nilrt-base-system-image-x64.tar
 
         You can install this on target by copying the file over to the target while the target is in safe mode and running the following commands:
 
@@ -139,7 +139,7 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
 
         The bootable recovery media, which you can install onto a USB memory stick or burn to a CD, is located at the following path:
 
-            tmp-glibc/deploy/images/x64/nilrt-recovery-media-x64.iso
+            tmp/deploy/images/x64/nilrt-recovery-media-x64.iso
 
         Boot your NI Linux Real-Time compatible hardware from the recovery media and follow on-screen instructions to perform a factory reset.
 
@@ -154,7 +154,7 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
     bash ../scripts/pipelines/build.toolchain.sh
     ```
 
-    During the build, a script is generated at `$BUILDDIR/tmp-glibc/deploy/sdk`, with a name like `oecore-x86_64-core2-64-toolchain-9.2.sh`. The script is a self-extracting archive, and can be copied to and executed on an appropriate host system to install the toolchain.
+    During the build, a script is generated at `$BUILDDIR/tmp/deploy/sdk`, with a name like `oecore-x86_64-core2-64-toolchain-9.2.sh`. The script is a self-extracting archive, and can be copied to and executed on an appropriate host system to install the toolchain.
 
     To build the toolchain for an x86_64 Windows host, there is a different script that can be used.
     
@@ -162,7 +162,7 @@ This project uses the [pyrex](https://github.com/garmin/pyrex) tool to transpare
     bash ../scripts/pipelines/build.cross-toolchain.sh
     ```
 
-    During the build, an archive is generated at `$BUILDDIR/tmp-glibc/deploy/sdk`, with a name like
+    During the build, an archive is generated at `$BUILDDIR/tmp/deploy/sdk`, with a name like
     `oecore-x86_64-core2-64-toolchain.tar.xz`. This archive can be extracted on a Windows system to
     to access the toolchain.
 

--- a/scripts/buildUSB.sh
+++ b/scripts/buildUSB.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-IMAGE_FILE="../build/tmp-glibc/deploy/images/x64/nilrt-base-bundle-image-x64.tar.bz2"
+IMAGE_FILE="../build/tmp/deploy/images/x64/nilrt-base-bundle-image-x64.tar.bz2"
 DISK_CONFIG="../sources/meta-nilrt/recipes-core/initrdscripts/files/disk_config_x64"
 ASK_FIRST=true
 

--- a/scripts/dev/upstream_merge/utils/test.py
+++ b/scripts/dev/upstream_merge/utils/test.py
@@ -5,7 +5,7 @@ import time
 
 from .shell_commands import execute_and_stream_cmd_output
 
-BUILD_DIR = "/build/tmp-glibc/deploy/images/x64/"
+BUILD_DIR = "/build/tmp/deploy/images/x64/"
 SAFEMODE_IMAGE = "nilrt-safemode-rootfs-x64.tar.gz"
 RUNMODE_IMAGE = "nilrt-base-system-image-x64.tar"
 

--- a/scripts/pipelines/build.extra-feeds.sh
+++ b/scripts/pipelines/build.extra-feeds.sh
@@ -83,7 +83,7 @@ if [ -n "${core_feed_path}" ]; then
 	echo "Pruning all packages from the extras feed which are already in core."
 	$DELETE_DUPLICATE_IPKS \
 		"${core_feed_path}" \
-		"./tmp-glibc/deploy/ipk"
+		"./tmp/deploy/ipk"
 fi
 
 # Package index generation must happen after we have deduped IPKs.

--- a/scripts/pipelines/build.vms.sh
+++ b/scripts/pipelines/build.vms.sh
@@ -44,7 +44,7 @@ EOF
 RECOVERY_IMAGE_RECIPE_NAME=nilrt-recovery-media
 PYREX_RUN=pyrex-run
 
-DEFAULT_IMAGES_DIR="./tmp-glibc/deploy/images/x64"
+DEFAULT_IMAGES_DIR="./tmp/deploy/images/x64"
 
 answers_file="${SCRIPT_RESOURCE_DIR}/ni_provisioning.answers"
 disk_size_mb=4096


### PR DESCRIPTION
Justification

[AB#3039672](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3039672)

# Changes

Upstream openembedded-core dropped support for TCLIBCAPPEND, making separate TMPDIRs such as tmp-glibc unnecessary.

This PR updates NILRT to follow upstream behavior by replacing all tmp-glibc references with tmp. This aligns NILRT with current
OE-Core defaults and ensures consistent TMPDIR usage across glibc and musl builds.

No functional changes are introduced; this is a cleanup to maintain compatibility with upstream OE-Core.



# Testing

* [x] Verified that all packages are generated in `tmp` dir only.


# Process

* [x] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.


__Suggested Reviewers:__
* @ni/rtos
