### PR TITLE
ni_provisioning.answers: Set a root password

### DIFF
--- a/scripts/pipelines/vm-resources/ni_provisioning.answers
+++ b/scripts/pipelines/vm-resources/ni_provisioning.answers
@@ -7,3 +7,6 @@ PROVISION_REBOOT_METHOD="poweroff"
 
 # Install auto discoverable ESPs to support all hypervisors
 PROVISION_BOOT_SCHEME="efi-auto"
+
+# Set an empty root password
+PROVISION_ROOT_PASSWORD=""


### PR DESCRIPTION
Update the provisioning answers file to set a blank root password

# Changes

Add PROVISION_ROOT_PASSWORD="" to the answers file used for our scripts. Without it provisioning may get stuck at the prompt for a root password. This should go in after this related [meta-nilrt PR](https://github.com/ni/meta-nilrt/pull/968) and should help to resolve [AB#3775174](https://dev.azure.com/ni/DevCentral/_workitems/edit/3775174).


# Testing

* [X] Ran the build.vms.sh script and confirmed the VM was built and has a blank root password.


# Process

*TODO: Check boxes that apply to this PR and are complete. Remove boxes that do not apply.*

* [X] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.


__Suggested Reviewers:__
* @ni/rtos
