### PR TITLE
estimate-usage: update x64 export path to gcc-13.4-oe

### DIFF
--- a/scripts/dev/estimate-usage/estimate-usage.sh
+++ b/scripts/dev/estimate-usage/estimate-usage.sh
@@ -51,7 +51,7 @@ get_latest_x86_64_images() {
     local default="$EXPORTS_DIR/ni/rtos/rtos_nilinuxrt/official/export"
     local search="${EXPORT_SEARCH_PATH_X86_64-$default}"
     local latest="$(identify_latest "$1" "$search")"
-    local presuffix="targets/linuxU/x64/gcc-4.7-oe/release"
+    local presuffix="targets/linuxU/x64/gcc-13.4-oe/release"
     local run_suffix="$presuffix/nilrt-base-system-image-x64.tar"
     local safe_suffix="$presuffix/standard_x64_safemode.tar.gz"
     cp -f "$latest/$run_suffix" "$1"


### PR DESCRIPTION
A recent ni-central PR updated the compiler version for rtos_nilinuxrt. Update the x86_64 export path from gcc-4.7-oe to gcc-13.4-oe to fix the "Publish image sizes" pipeline failure. 

[AB#3600454](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3600454)

# Changes

- Updated the x86_64 export presuffix path in `get_latest_x86_64_images()` from `gcc-4.7-oe` to `gcc-13.4-oe`.
- No changes to the ARMv7-A export path — it remains unchanged as the ARM compiler path was not affected.


# Testing

- Verified the correct path exists on the export server:
  `\\nirvana\perforceExports\build\exports\ni\rtos\rtos_nilinuxrt\official\export\26.5\26.5.0d33\targets\linuxU\x64\gcc-13.4-oe\release`
- Cross-referenced with the ni-central [compiler PR](https://dev.azure.com/ni/DevCentral/_git/ni-central/pullrequest/1027605?_a=files&path=/src/rtos/rtosimagesd/rtos_nilinuxrt) to confirm the path change.
- Confirmed the ARMv7-A path is unaffected and requires no update.


# Process

- [x] Verified export path on the build server
- [x] Confirmed alignment with the compiler version PR in ni-central
- [x] Validated that only the x64 path changed; ARM path is unchanged

* [x] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.
