### PR TITLE
Update ARM disk usage scripts

### DIFF
--- a/scripts/dev/estimate-usage/estimate-usage.armv7-a.runmode.sh
+++ b/scripts/dev/estimate-usage/estimate-usage.armv7-a.runmode.sh
@@ -7,10 +7,10 @@ print_fs_usage() {
     # Format the UBI volume and create a clean ubifs...
     ubimkvol /dev/ubi0 -N mynandvol -m >/dev/null
     # ...reserving zero space for the root, similar to the cRIO-9068
-    mkfs.ubifs -R 0 /dev/ubi0_0
+    mkfs.ubifs --compr=zlib -R 0 /dev/ubi0_0
     local mountpoint="$(mktemp -d)"
     mount -t ubifs ubi0 "$mountpoint"
-    tar -xOf "$image" ./data.tar.gz | tar -xz -C "$mountpoint"
+    tar -xOf "$image" data.tar.xz | tar -xJ -C "$mountpoint"
     sync
     echo -ne "$image\tARMv7-A\trunmode\tdisk footprint\t"
     df -h "$mountpoint" | tail -1 | awk '{ print $3; }'

--- a/scripts/dev/estimate-usage/estimate-usage.armv7-a.safemode.sh
+++ b/scripts/dev/estimate-usage/estimate-usage.armv7-a.safemode.sh
@@ -14,8 +14,8 @@ print_fs_usage() {
     echo -ne "$image\tARMv7-A\tsafemode\tdisk footprint\t"
     du --apparent-size -h "$image" | awk '{ print $1; }'
     echo -ne "$image\tARMv7-A\tsafemode\tkernel + ramdisk\t"
-    local kernel_size="$(dumpimage "$image" -T flat_dt -p 0 -o /dev/fd/3 3>&1 >/dev/null | gzip -d | wc -c)"
-    local ramdisk_size="$(dumpimage "$image" -T flat_dt -p 16 -o /dev/fd/3 3>&1 >/dev/null | xz -d | wc -c)"
+    local kernel_size="$(dumpimage "$image" -T flat_dt -p 0 -o /dev/fd/3 3>&1 >/dev/null | wc -c)"
+    local ramdisk_size="$(dumpimage "$image" -T flat_dt -p 23 -o /dev/fd/3 3>&1 >/dev/null | xz -d | wc -c)"
     numfmt --to=iec "$(($kernel_size + $ramdisk_size))"
     if test "$input_image" != "$image"; then
         rm "$image"

--- a/scripts/dev/estimate-usage/estimate-usage.sh
+++ b/scripts/dev/estimate-usage/estimate-usage.sh
@@ -59,15 +59,12 @@ get_latest_x86_64_images() {
 }
 
 get_latest_armv7_a_images() {
-    local default="$EXPORTS_DIR/ni/nilr/nilrt_os_common/official/export"
+    local default="$EXPORTS_DIR/ni/rtos/rtos_nilinuxrt/official/export"
     local search="${EXPORT_SEARCH_PATH_ARMV7_A-$default}"
     local latest="$(identify_latest "$1" "$search")"
-    local run_presuffix="distribution-systemlink_dkms/release/RT Images/SystemLink"
-    # There's a versioned directory here for some reason, but at least it's the
-    # only thing there and we can just use head -1 to get it.
-    run_presuffix="$run_presuffix/$(ls "$latest/$run_presuffix" | head -1)"
-    local run_suffix="$run_presuffix/systemlink-linux-armv7-a.tar"
-    local safe_suffix="crio_zynq_safemode.itb"
+    local presuffix="targets/linuxU/armv7-a/gcc-13.4-oe/release"
+    local run_suffix="$presuffix/nilrt-base-system-image-xilinx-zynq.tar"
+    local safe_suffix="$presuffix/linux_safemode.itb"
     cp -f "$latest/$run_suffix" "$1"
     cp -f "$latest/$safe_suffix" "$2"
 }

--- a/scripts/dev/estimate-usage/estimate-usage.sh
+++ b/scripts/dev/estimate-usage/estimate-usage.sh
@@ -97,7 +97,7 @@ log "Copying x86_64 scripts into VM"
 scp -P 2222 $SSH_OPTIONS "$HERE/estimate-usage.x86_64.runmode.sh" root@localhost:.
 scp -P 2222 $SSH_OPTIONS "$HERE/estimate-usage.x86_64.safemode.sh" root@localhost:.
 get_latest_x86_64_images "$RUNIMAGE" "$SAFEIMAGE"
-log "Running x86_64 subscripts in VM"
+log "Running x86_64 scripts in VM"
 cat "$RUNIMAGE" | ssh -p 2222 $SSH_OPTIONS root@localhost ./estimate-usage.x86_64.runmode.sh | cut -d $'\t' -f 2-
 cat "$SAFEIMAGE" | ssh -p 2222 $SSH_OPTIONS root@localhost ./estimate-usage.x86_64.safemode.sh | cut -d $'\t' -f 2-
 
@@ -105,6 +105,6 @@ log "Copying ARMv7-A scripts into VM"
 scp -P 2222 $SSH_OPTIONS "$HERE/estimate-usage.armv7-a.runmode.sh" root@localhost:.
 scp -P 2222 $SSH_OPTIONS "$HERE/estimate-usage.armv7-a.safemode.sh" root@localhost:.
 get_latest_armv7_a_images "$RUNIMAGE" "$SAFEIMAGE"
-log "Running ARMv7-A subscripts in VM"
+log "Running ARMv7-A scripts in VM"
 cat "$RUNIMAGE" | ssh -p 2222 $SSH_OPTIONS root@localhost ./estimate-usage.armv7-a.runmode.sh | cut -d $'\t' -f 2-
 cat "$SAFEIMAGE" | ssh -p 2222 $SSH_OPTIONS root@localhost ./estimate-usage.armv7-a.safemode.sh | cut -d $'\t' -f 2-


### PR DESCRIPTION
# Changes

Use upgraded ARM images for disk usage estimation.
Minor rewording of log messages.

WI: [AB#3791351](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3791351)

# Testing

- [x] Ran `./estimate-usage.sh` 
- [x] Ran `publish_image_sizes.py <output of ./estimate-usage.sh>`

# Process

* [x] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.