### PR TITLE
scripts, docs: Use root instead of NIAuth admin for target access

### DIFF
--- a/docs/README.kernel.md
+++ b/docs/README.kernel.md
@@ -255,25 +255,25 @@ KERNEL_VERSION=`make -s kernelrelease`
    this command:
 
    ```bash
-   ssh admin@$TARGET 'test ! -h /boot/runmode/bzImage && mv /boot/runmode/bzImage /boot/runmode/bzImage-`uname -r`'
+   ssh root@$TARGET 'test ! -h /boot/runmode/bzImage && mv /boot/runmode/bzImage /boot/runmode/bzImage-`uname -r`'
    ```
 
 2. Copy the new kernel to the target with SSH.
 
    ```bash
-   scp arch/x86/boot/bzImage admin@$TARGET:/boot/runmode/bzImage-$KERNEL_VERSION
+   scp arch/x86/boot/bzImage root@$TARGET:/boot/runmode/bzImage-$KERNEL_VERSION
    ```
 
    Rewrite the symlink used by the bootloader.
 
    ```bash
-   ssh admin@$TARGET ln -sf bzImage-$KERNEL_VERSION /boot/runmode/bzImage
+   ssh root@$TARGET ln -sf bzImage-$KERNEL_VERSION /boot/runmode/bzImage
    ```
 
 3. Copy the kernel modules to the target.
 
    ```bash
-   tar cz -C $TEMP_MODULES lib | ssh admin@$TARGET tar xz -C /
+   tar cz -C $TEMP_MODULES lib | ssh root@$TARGET tar xz -C /
    ```
 
    Note that the build and source symlinks in the modules directory do
@@ -288,19 +288,19 @@ KERNEL_VERSION=`make -s kernelrelease`
    provides an interactive menu to choose whether to boot into safemode:
 
    ```bash
-   ssh admin@$TARGET fw_setenv bootdelay 5
+   ssh root@$TARGET fw_setenv bootdelay 5
    ```
 
 5. Reboot the target.
 
    ```bash
-   ssh admin@$TARGET reboot
+   ssh root@$TARGET reboot
    ```
 
 6. (optional) Check version of the updated kernel on the target.
 
    ```bash
-   ssh admin@$TARGET uname -r
+   ssh root@$TARGET uname -r
    ```
 
 
@@ -332,16 +332,16 @@ over the network, saving limited disk space resources.
 2. Install sshfs on the target and load the module for fuse.
 
    ```bash
-   ssh admin@$TARGET "opkg update && opkg install sshfs-fuse"
-   ssh admin@$TARGET modprobe fuse
+   ssh root@$TARGET "opkg update && opkg install sshfs-fuse"
+   ssh root@$TARGET modprobe fuse
    ```
 
 3. Mount the kernel source on the target. Note that user and host
    in this case are the values for the host build machine.
 
    ```bash
-   ssh admin@$TARGET mkdir /usr/src/linux
-   ssh admin@$TARGET sshfs <user>@<host>:<path_to_linux_source> /usr/src/linux
+   ssh root@$TARGET mkdir /usr/src/linux
+   ssh root@$TARGET sshfs <user>@<host>:<path_to_linux_source> /usr/src/linux
    ```
 
 #### With `scp` and `tar`
@@ -350,8 +350,8 @@ If the target has sufficient disk space, the source can be copied to the
 target, as was done earlier when copying the modules to the target.
 
 ```bash
-ssh admin@$TARGET mkdir /usr/src/linux
-tar cz --exclude=./.git --exclude=$TEMP_MODULES . | ssh admin@$TARGET tar xz --no-same-owner -C /usr/src/linux
+ssh root@$TARGET mkdir /usr/src/linux
+tar cz --exclude=./.git --exclude=$TEMP_MODULES . | ssh root@$TARGET tar xz --no-same-owner -C /usr/src/linux
 ```
 
 ### Using the Source with DKMS
@@ -360,7 +360,7 @@ The following steps are all run on the target. This can be done either by
 opening an ssh session as below or through a serial connection.
 
 ```bash
-ssh admin@$TARGET
+ssh root@$TARGET
 ```
 
 1. Fix dangling build and source symlinks.

--- a/scripts/dev/upstream_merge/kernel_build_and_test.py
+++ b/scripts/dev/upstream_merge/kernel_build_and_test.py
@@ -103,7 +103,7 @@ def setup_passwordless_ssh_to_build_machine(build_host_ip, build_user):
 
     print("[SSH-SETUP] Refreshing known_hosts entries")
 
-    # Extract IP from ssh_target (admin@ip → ip)
+    # Extract IP from ssh_target (root@ip → ip)
     target_ip = config.ssh_target.split("@")[-1] if config.ssh_target else None
 
     # Remove stale entries

--- a/scripts/dev/upstream_merge/utils/test.py
+++ b/scripts/dev/upstream_merge/utils/test.py
@@ -104,7 +104,7 @@ def test_safemode_installation(ssh_connection):
     current_directory = os.getcwd()
     copy = execute_and_stream_cmd_output(
         f"scp {current_directory}{BUILD_DIR}{SAFEMODE_IMAGE} "
-        f"{ssh_connection}:/home/admin"
+        f"{ssh_connection}:/root"
     )
     if copy[0] != 0:
         return copy

--- a/scripts/tests/fio-test/iops-file-randread.fio
+++ b/scripts/tests/fio-test/iops-file-randread.fio
@@ -11,5 +11,5 @@ numjobs=4
 [random_reads]
 rw=randread
 name=iops-file-randread
-filename=/home/root/test_file
+filename=/root/test_file
 size=2GB

--- a/scripts/tests/fio-test/iops-file-randrw.fio
+++ b/scripts/tests/fio-test/iops-file-randrw.fio
@@ -11,5 +11,5 @@ numjobs=4
 [random_read_write]
 rw=randrw
 name=iops-file-randrw
-filename=/home/root/test_file
+filename=/root/test_file
 size=2GB

--- a/scripts/tests/fio-test/iops-file-read.fio
+++ b/scripts/tests/fio-test/iops-file-read.fio
@@ -11,5 +11,5 @@ numjobs=4
 [sequential_read]
 rw=read
 name=iops-file-read
-filename=/home/root/test_file
+filename=/root/test_file
 size=2GB

--- a/scripts/tests/fio-test/latency-randread.fio
+++ b/scripts/tests/fio-test/latency-randread.fio
@@ -11,5 +11,5 @@ numjobs=1
 [random_reads]
 rw=randread
 name=latency-randread
-filename=/home/root/test_file
+filename=/root/test_file
 size=2GB

--- a/scripts/tests/fio-test/latency-randrw.fio
+++ b/scripts/tests/fio-test/latency-randrw.fio
@@ -11,5 +11,5 @@ numjobs=1
 [random_read_write]
 rw=randrw
 name=latency-randrw
-filename=/home/root/test_file
+filename=/root/test_file
 size=2GB

--- a/scripts/tests/fio-test/throughput-file-randread.fio
+++ b/scripts/tests/fio-test/throughput-file-randread.fio
@@ -11,5 +11,5 @@ numjobs=4
 [random_reads]
 rw=randread
 name=throughput-file-randread
-filename=/home/root/test_file
+filename=/root/test_file
 size=2GB

--- a/scripts/tests/fio-test/throughput-file-randrw.fio
+++ b/scripts/tests/fio-test/throughput-file-randrw.fio
@@ -11,5 +11,5 @@ numjobs=4
 [random_read_write]
 rw=randrw
 name=throughput-file-randrw
-filename=/home/root/test_file
+filename=/root/test_file
 size=2GB

--- a/scripts/tests/fio-test/throughput-file-read.fio
+++ b/scripts/tests/fio-test/throughput-file-read.fio
@@ -11,5 +11,5 @@ numjobs=4
 [sequential_read]
 rw=read
 name=throughput-file-read
-filename=/home/root/test_file
+filename=/root/test_file
 size=2GB

--- a/scripts/tests/provisioning/migrate_vm_to_safemode.expect
+++ b/scripts/tests/provisioning/migrate_vm_to_safemode.expect
@@ -16,7 +16,7 @@ set ipk_feeds [lrange $argv 2 end]
 # default, if none is specified.
 set vm_host_ip "10.0.2.2"
 # Set the login username
-set USER admin
+set USER root
 
 # boot the VM with the run-vm script
 spawn [lindex $argv 0] -- -device e1000,netdev=n1 -netdev user,id=n1,ipv6=off,net=10.0.2.0/24,host=$vm_host_ip
@@ -101,7 +101,7 @@ expect {
 	}
 }
 
-set USER admin
+set USER root
 
 set timeout 90
 expect {

--- a/scripts/tests/provisioning/test_rauc_provision.expect
+++ b/scripts/tests/provisioning/test_rauc_provision.expect
@@ -16,7 +16,7 @@ set ipk_feeds [lrange $argv 2 end]
 # default, if none is specified.
 set vm_host_ip "10.0.2.2"
 # Set the login username
-set USER admin
+set USER root
 
 set RE_PROMPT "(admin|root)@.*# $"
 

--- a/scripts/tests/provisioning/test_safemode_provision.expect
+++ b/scripts/tests/provisioning/test_safemode_provision.expect
@@ -16,7 +16,7 @@ set ipk_feeds [lrange $argv 2 end]
 # default, if none is specified.
 set vm_host_ip "10.0.2.2"
 # Set the login username
-set USER admin
+set USER root
 
 # boot the VM with the run-vm script
 spawn [lindex $argv 0] -s -- -device e1000,netdev=n1 -netdev user,id=n1,ipv6=off,net=10.0.2.0/24,host=$vm_host_ip


### PR DESCRIPTION

# Justification
[AB#3650235](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3650235)

# Changes

The system login is moving off the NIAuth-backed "admin" user to the local "root" user, since ni-auth no longer ships the NSS/PAM modules that resolved the admin identity.

Update the scripts and docs that log in to or reference the target accordingly:
- provisioning expect tests: USER `admin -> root`.
- upstream_merge test util: `scp/ssh path :/home/admin -> :/root`. ([FYI](https://dev.azure.com/ni/DevCentral/_git/labview/pullRequest/1303859?discussionId=10158552#1782805518))
- README.kernel.md: ssh/scp `admin@$TARGET -> root@$TARGET`.
- Update `fio-tests` to use `/root` as root `HOME_DIR`.


# Testing
Performed testing under this [meta-nilrt](https://github.com/ni/meta-nilrt/pull/1026) PR that has all the functional changes.
FYI: This needs to be merged only once meta-nilrt PR is merged.
