### PR TITLE
repos.conf: Update meta-rauc to wrynose

### DIFF
--- a/scripts/dev/upstream_merge/repos.conf
+++ b/scripts/dev/upstream_merge/repos.conf
@@ -10,6 +10,6 @@ sources/meta-security        https://git.yoctoproject.org/meta-security         
 sources/meta-sdr             https://github.com/balister/meta-sdr                  master                nilrt/master/next
 sources/meta-qt5             https://github.com/meta-qt5/meta-qt5                  master                nilrt/master/next
 sources/meta-qt5-extra       https://github.com/schnitzeltony/meta-qt5-extra       master                nilrt/master/next
-sources/meta-rauc            https://github.com/rauc/meta-rauc                     master                nilrt/master/next
+sources/meta-rauc            https://github.com/rauc/meta-rauc                     wrynose               nilrt/master/next
 sources/pyrex                https://github.com/garmin/pyrex                       master                nilrt/master/next
 sources/meta-mingw           https://git.yoctoproject.org/meta-mingw               wrynose               nilrt/master/next


### PR DESCRIPTION
# Changes
There is now a wrynose branch for [meta-rauc](https://github.com/rauc/meta-rauc/tree/wrynose).

# Testing
- [x] Built pyrex container
- [x] bitbake packagefeed-ni-core
- [x] bitbake packagegroup-ni-desirable
- [x] bitbake package-index && bitbake nilrt-base-system-image

