### PR TITLE
.gitmodules: Update branch refs for 26.5 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,56 +1,56 @@
 [submodule "sources/bitbake"]
 	path = sources/bitbake
 	url = ../bitbake.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/meta-cloud-services"]
 	path = sources/meta-cloud-services
 	url = ../meta-cloud-services.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/meta-openembedded"]
 	path = sources/meta-openembedded
 	url = ../meta-openembedded.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/meta-nilrt"]
 	path = sources/meta-nilrt
 	url = ../meta-nilrt.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/meta-selinux"]
 	path = sources/meta-selinux
 	url = ../meta-selinux.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/openembedded-core"]
 	path = sources/openembedded-core
 	url = ../openembedded-core.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/meta-mingw"]
 	path = sources/meta-mingw
 	url = ../meta-mingw.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/meta-virtualization"]
 	path = sources/meta-virtualization
 	url = ../meta-virtualization.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/meta-security"]
 	path = sources/meta-security
 	url = ../meta-security.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/meta-sdr"]
 	path = sources/meta-sdr
 	url = ../meta-sdr.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/meta-qt5"]
 	path = sources/meta-qt5
 	url = ../meta-qt5.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/meta-qt5-extra"]
 	path = sources/meta-qt5-extra
 	url = ../meta-qt5-extra.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/meta-rauc"]
 	path = sources/meta-rauc
 	url = ../meta-rauc.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap
 [submodule "sources/pyrex"]
 	path = sources/pyrex
 	url = ../pyrex.git
-	branch = nilrt/master/scarthgap
+	branch = nilrt/26.5/scarthgap


### PR DESCRIPTION
# Changes
Updated .gitmodules to point to 26.5 branches
[AB#3738543](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3738543)

# Testing
None

# Process
None

__Suggested Reviewers:__
* @ni/rtos
