### PR TITLE
BB_HASHSERVE Warning fix

### DIFF
--- a/ni-oe-init-build-env
+++ b/ni-oe-init-build-env
@@ -108,7 +108,13 @@ echo "BB_NUMBER_THREADS=${BB_NUMBER_THREADS}"
 # into the build workspace, if one needs to be created.
 export TEMPLATECONF=${TEMPLATECONF:-${NILRT_ROOT}/sources/meta-nilrt/conf/templates/default}
 
-export SSTATE_MIRRORS="${SSTATE_MIRRORS:-} ${sstate_mirrors[@]/%/ \\n}"
+# Only export SSTATE_MIRRORS when there is an actual value. Exporting an
+# empty/whitespace-only string trips bitbake's hash-equivalence sanity check,
+# which treats any non-empty SSTATE_MIRRORS (even whitespace) as a configured
+# mirror and emits a spurious warning.
+if [ -n "${SSTATE_MIRRORS:-}" ] || [ ${#sstate_mirrors[@]} -gt 0 ]; then
+	export SSTATE_MIRRORS="${SSTATE_MIRRORS:-} ${sstate_mirrors[@]/%/ \\n}"
+fi
 
 # Define here all NILRT-specific variables which need to be passed to bitbake
 # (should include everything we've set above which is non-standard)


### PR DESCRIPTION
# Changes

`ni-oe-init-build-env` exported `SSTATE_MIRRORS` unconditionally. When no
`-s/--sstate-mirror` argument was passed, the `sstate_mirrors` array was empty
and the expansion collapsed to a whitespace-only string (`" "`).

OE-core recently enabled hash equivalence by default via [commit](https://github.com/ni/openembedded-core/commit/4a388406acf0210e8a47c4733979256b10e078ff), which adds
`BB_HASHSERVE ??= "auto"`. With `"auto"`, bitbake auto-starts a local
hash-equivalence server and resolves `BB_HASHSERVE` to
`unix:///…/hashserve.sock`. That flips the local-hashserver condition in
`sanity.bbclass` to true, and combined with the whitespace `SSTATE_MIRRORS`,
the following warning appears on every build:

> WARNING: You are using a local hash equivalence server but have configured an
> sstate mirror. This will likely mean no sstate will match from the mirror. ...

The sanity check treats any non-empty `SSTATE_MIRRORS` — even whitespace — as a
configured mirror, so the empty value tripped it. This previously went
unnoticed on scarthgap because `BB_HASHSERVE` had no default there and stayed
empty, so the `unix://` condition was never met.

This PR guards the export so `SSTATE_MIRRORS` is only set when a real mirror is
provided (via `-s`) or was already present in the environment. The warning is
intentionally still emitted when an actual mirror is configured, since it is
legitimate in that case.

# Justification
[AB#3738536](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3738536).

# Testing

- Sourced `ni-oe-init-build-env` with **no** `-s` argument and confirmed:
  - `bitbake -e | grep ^SSTATE_MIRRORS=` shows `SSTATE_MIRRORS` is empty/unset
    (previously `"  "`).
  - The hash-equivalence warning no longer appears at parse time.
- Sourced with a real mirror (`-s "file://.*" "http://<server>/sstate/PATH"`)
  and confirmed `SSTATE_MIRRORS` is populated correctly and that the legitimate
  warning still appears (expected).
- Ran a build 
  - [x] `bitbake packagefeed-ni-core`
  - [x] `bitbake package-index`
  - [x] `bitbake nilrt-safemode-rootfs`
  - [x] `bitbake nilrt-base-system-image` 
  

  to confirm no regression in environment setup.


__Suggested Reviewers:__
* @ni/rtos
