### PR TITLE
upstream_merge: Clean up sample automation config

### DIFF
--- a/scripts/dev/upstream_merge/automation_conf.json
+++ b/scripts/dev/upstream_merge/automation_conf.json
@@ -4,7 +4,7 @@
     "conf_file_path": "scripts/dev/upstream_merge/repos.conf",
     "force_checkout": false,
     "upstream_repo_name": "automerge_upstream",
-    "merge_branch_name": "dev/automerge/ni",
+    "merge_branch_name": "",
     "fork_name": "myfork",
     "email_log_level": 0,
     "log_level": 10,
@@ -22,8 +22,7 @@
     "toolchain_prefix": "",
     "ssh_target": "",   
     "build_host_ip": "",
-    "build_user": "",
-    "work_item_id": ""
+    "build_user": ""
     }
 }
 


### PR DESCRIPTION
# Changes
- Clear default merge_branch_name in sample config
- Remove unused work_item_id field

# Justification
[AB#3174387](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3174387).
When the upstream merge pipeline runs for dist-current, it generates [PRs.](https://github.com/ni/openembedded-core/pull/205) However, if the upstream merge pipeline is subsequently executed for dist-next, the corresponding branch may be deleted and recreated with updates from dist-next [PRs](https://github.com/ni/openembedded-core/pull/206).