### PR TITLE
upstream-merge: add missing git_branch import

### DIFF
--- a/scripts/dev/upstream_merge/kernel_build_and_test.py
+++ b/scripts/dev/upstream_merge/kernel_build_and_test.py
@@ -15,6 +15,7 @@ from utils.git_commands import (
     git_clone,
     git_checkout,
     git_pull,
+    git_branch,
 )
 from utils.git_repo import GitRepo
 from json_config import JsonConfig
@@ -277,9 +278,9 @@ def create_kernel_pr(args, config, latest_tag, defconfig_changed):
     )
     # Set fork details for GitRepo
     git_obj.fork_name = config.fork_name
-    git_obj.fork_url = f"https://github.com/{config.username}/linux.git"
+    git_obj.fork_url = remote_url
     
-    _, branch_name = git_branch(show_current=True)
+    _, branch_name = git_branch(branch_name="",show_current=True)
     branch_name = branch_name.strip()
     status, msg = push_branch_and_create_pr(
         git_obj,


### PR DESCRIPTION
# Changes
  AB Work Item -https://dev.azure.com/ni/DevCentral/_workitems/edit/3181646
- Add missing git_branch import , error occured during pr_creation step . 


# Testing

- Verified code path compiles correctly
- Fix addresses runtime NameError observed in pipeline


# Process

The code was updated to use git_branch(show_current=True)

* [x] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.


__Suggested Reviewers:__
