### PR TITLE
auto.conf: Configure BB_HASHSERVE_DB_DIR to use the shared SSTATE_DIR

### DIFF
--- a/scripts/azdo/conf/auto.conf
+++ b/scripts/azdo/conf/auto.conf
@@ -10,3 +10,4 @@ BUILDHISTORY_COMMIT = "1"
 # The buildstats class records performance statistics about each task executed
 # during the build (e.g. elapsed time, CPU usage, and I/O usage).
 USER_CLASSES += "buildstats"
+BB_HASHSERVE_DB_DIR = "${SSTATE_DIR}"


### PR DESCRIPTION
# Changes
The sstate cache is shared across multiple build directories, while the hash equivalence database was previously created inside each individual build directory. This prevented builds from sharing hash equivalence information, reducing sstate reuse and generating warnings during the build.

Store the hash equivalence database alongside the shared sstate cache so all builds use the same database, improving sstate reuse and resolving the warning about the hash equivalency database location.

# Justification
[AB#3918195](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3918195).

# Testing
Followed similar steps as done [here ](https://dev.azure.com/ni/DevCentral/_build/results?buildId=20799448&view=logs&j=3c108210-387a-5e25-97fa-da85b630fc6f&t=a41bbec2-9444-536b-41b3-124eaa2976d9&l=1047) and verified the changes.


__Suggested Reviewers:__
* @ni/rtos
