### PR TITLE
meta-secure-core: Add meta-secure-core as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -54,3 +54,7 @@
 	path = sources/pyrex
 	url = ../pyrex.git
 	branch = nilrt/master/scarthgap
+[submodule "sources/meta-secure-core"]
+	path = sources/meta-secure-core
+	url = ../meta-secure-core.git
+	branch = nilrt/master/scarthgap

--- a/scripts/dev/upstream_merge/repos.conf
+++ b/scripts/dev/upstream_merge/repos.conf
@@ -12,3 +12,4 @@ sources/meta-qt5-extra       https://github.com/schnitzeltony/meta-qt5-extra    
 sources/meta-rauc            https://github.com/rauc/meta-rauc                     scarthgap             nilrt/master/scarthgap
 sources/pyrex                https://github.com/garmin/pyrex                       master                nilrt/master/scarthgap
 sources/meta-mingw           https://git.yoctoproject.org/meta-mingw               scarthgap             nilrt/master/scarthgap
+sources/meta-secure-core     https://github.com/Wind-River/meta-secure-core        scarthgap             nilrt/master/scarthgap


### PR DESCRIPTION
# Changes

Add meta-secure-core as a submodule


# Testing

* [x] Verified `git submodule update --init` works correctly


# Process

* [ ] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.


__Suggested Reviewers:__
* @ni/rtos
