### PR TITLE
meta-secure-core: Add meta-secure-core as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,7 @@
 	path = sources/pyrex
 	url = ../pyrex.git
 	branch = nilrt/master/next
+[submodule "sources/meta-secure-core"]
+	path = sources/meta-secure-core
+	url = ../meta-secure-core.git
+	branch = nilrt/master/next


### PR DESCRIPTION
# Changes

Add meta-secure-core as a submodule


# Testing

* [x] Verified `git submodule update --init` works correctly


# Process

* ~~[ ] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref.~~


__Suggested Reviewers:__
* @ni/rtos
