### PR TITLE
repos.conf: Add meta-secure-core for upstream merge

### DIFF
--- a/scripts/dev/upstream_merge/repos.conf
+++ b/scripts/dev/upstream_merge/repos.conf
@@ -13,3 +13,4 @@ sources/meta-qt5-extra       https://github.com/schnitzeltony/meta-qt5-extra    
 sources/meta-rauc            https://github.com/rauc/meta-rauc                     wrynose               nilrt/master/next
 sources/pyrex                https://github.com/garmin/pyrex                       master                nilrt/master/next
 sources/meta-mingw           https://git.yoctoproject.org/meta-mingw               wrynose               nilrt/master/next
+sources/meta-secure-core     https://github.com/Wind-River/meta-secure-core        wrynose               nilrt/master/next


### PR DESCRIPTION
# Changes

`meta-secure-core` submodule was added as a part of commit https://github.com/ni/nilrt/commit/7059c0de9aa47399e08d5cdd855970c84cb9afa1, but its corresponding upstream_repo was not included in repos.conf file. This PR includes the required change.

Changes similar to the scarthgap PR: https://github.com/ni/nilrt/pull/370

Also, cherry picked the corresponding commit https://github.com/ni/meta-nilrt/commit/93c0de20713500f21ae7bba02781b76d8fa935a4

# Testing

- [x] `bitbake packagefeed-ni-core`
- [x] `nilrt-safemode-rootfs`
- [x] `nilrt-base-system-image`
- [x] Verified the image build and installation works


# Process

* [ ] This PR should be cherry-picked to the [`next/`](https://github.com/ni/nilrt/tree/nilrt/master/next) ref. -> Not applicable
